### PR TITLE
Pin solidity-parser to sc-forks#master 

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "req-cwd": "^1.0.1",
     "shelljs": "^0.7.4",
     "sol-explore": "^1.6.2",
-    "solidity-parser": "0.3.0"
+    "solidity-parser": "git+https://github.com/sc-forks/solidity-parser.git"
   },
   "devDependencies": {
     "crypto-js": "^3.1.9-1",


### PR DESCRIPTION
+ This is temporary, pending npm publication of recent changes to SP.
+ SP uses `prepublish` to build the parser and can't be installed as a dep from its git repo.