### PR TITLE
Use coverage network port if available

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -1,3 +1,5 @@
+/* eslint no-unused-expressions: ["error", { "allowShortCircuit": true }]*/
+
 /**
  * Methods in this file walk the AST and call the instrumenter
  * functions where appropriate, which determine where to inject events.
@@ -21,7 +23,7 @@ parse.BlockStatement = function parseBlockStatement(contract, expression) {
 };
 
 parse.CallExpression = function parseCallExpression(contract, expression) {
-  // In any given chain of call expressions, only the head callee is an Identifier node 
+  // In any given chain of call expressions, only the head callee is an Identifier node
   if (expression.callee.type === 'Identifier') {
     instrumenter.instrumentStatement(contract, expression);
     parse[expression.callee.type] &&
@@ -86,7 +88,7 @@ parse.FunctionDeclaration = function parseFunctionDeclaration(contract, expressi
 parse.IfStatement = function parseIfStatement(contract, expression) {
   instrumenter.instrumentStatement(contract, expression);
   instrumenter.instrumentIfStatement(contract, expression);
-  
+
   parse[expression.consequent.type] &&
   parse[expression.consequent.type](contract, expression.consequent);
 


### PR DESCRIPTION
+ Includes a unit test for the coverage network declarations - unfortunately this is one that has to be verified manually by seeing what port is logged while coverage runs. Also disabled for CI because of the container memory limit issue.