### PR TITLE
Add topic logging to coverageMap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 allFiredEvents
+scTopics
 coverage.json
 coverage/
 node_modules/

--- a/bin/exec.js
+++ b/bin/exec.js
@@ -41,6 +41,7 @@ function cleanUp(err) {
   shell.config.silent = true;
   shell.rm('-Rf', `${coverageDir}`);
   shell.rm('./allFiredEvents');
+  shell.rm('./scTopics');
   if (testrpcProcess) { testrpcProcess.kill(); }
 
   if (err) {

--- a/lib/coverageMap.js
+++ b/lib/coverageMap.js
@@ -6,6 +6,7 @@
 const SolidityCoder = require('web3/lib/solidity/coder.js');
 const path = require('path');
 const keccak = require('keccakjs');
+const fs = require('fs');
 
 /**
  * Converts solcover event data into an object that can be
@@ -64,10 +65,20 @@ module.exports = class CoverageMap {
       return hash.digest('hex');
     });
 
-    this.lineTopics.push(keccakhex('__Coverage' + info.contractName + '(string,uint256)'));
-    this.functionTopics.push(keccakhex('__FunctionCoverage' + info.contractName + '(string,uint256)'));
-    this.branchTopics.push(keccakhex('__BranchCoverage' + info.contractName + '(string,uint256,uint256)'));
-    this.statementTopics.push(keccakhex('__StatementCoverage' + info.contractName + '(string,uint256)'));
+    const lineHash = keccakhex('__Coverage' + info.contractName + '(string,uint256)');
+    const fnHash = keccakhex('__FunctionCoverage' + info.contractName + '(string,uint256)');
+    const branchHash = keccakhex('__BranchCoverage' + info.contractName + '(string,uint256,uint256)');
+    const statementHash = keccakhex('__StatementCoverage' + info.contractName + '(string,uint256)');
+
+    this.lineTopics.push(lineHash);
+    this.functionTopics.push(fnHash);
+    this.branchTopics.push(branchHash);
+    this.statementTopics.push(statementHash);
+
+    fs.appendFileSync('./scTopics', `${lineHash}\n`);
+    fs.appendFileSync('./scTopics', `${fnHash}\n`);
+    fs.appendFileSync('./scTopics', `${branchHash}\n`);
+    fs.appendFileSync('./scTopics', `${statementHash}\n`);
   }
 
   /**


### PR DESCRIPTION
Part one of #9. Writes topic hashes to a file that testrpc can load and filter against. Also removes this meta data file on program close. 