### PR TITLE
Small exec.js cleanup, clarify port options settings in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ some additional options:
 + **port**: *{ Number }* Port to run testrpc on / have truffle connect to. (Default: 8555)
 + **accounts**: *{ Number }* Number of accounts to launch testrpc with. (Default: 35)
 + **testrpcOptions**: *{ String }* options to append to a command line invocation of testrpc.
-  + ex: `--secure --unlock "0x1234..." --unlock "0xabcd..."`.
-  + NB: if you specify the port in your rpc options string, also declare it as a `port` option.
+  + ex: `--secure --port 8555 --unlock "0x1234..." --unlock "0xabcd..."`.
+  + NB: you should specify a port in your rpc options string and also declare it in the config's `port` option.
 + **testCommand**: *{ String }* By default solidity-coverage runs `truffle test`. This option lets
 you run an arbitrary test command instead, like: `mocha --timeout 5000`.
   + remember to set the config's port option to whatever port your tests use (probably 8545).

--- a/bin/exec.js
+++ b/bin/exec.js
@@ -73,13 +73,7 @@ if (config.silent) {
 // environment folder.
 log('Generating coverage environment');
 try {
-  // Truffle environment:
-  // contracts/
-  // test/
-  // migrations/
-  // truffle.js
-
-  let files = shell.ls(`${workingDir}`);
+  let files = shell.ls(workingDir);
   const nmIndex = files.indexOf('node_modules');
 
   if (!config.copyNodeModules && nmIndex > -1) {
@@ -87,16 +81,15 @@ try {
   }
 
   files = files.map(file => `${workingDir}/` + file);
-  shell.mkdir(`${coverageDir}`);
-  shell.cp('-R', files, `${coverageDir}`);
+  shell.mkdir(coverageDir);
+  shell.cp('-R', files, coverageDir);
 
   const truffleConfig = reqCwd.silent(`${workingDir}/truffle.js`);
 
-  // Coverage network opts specified: copy truffle.js whole to coverage environment
+  // Coverage network opts specified: use port if declared
   if (truffleConfig && truffleConfig.networks && truffleConfig.networks.coverage) {
     port = truffleConfig.networks.coverage.port || port;
-    shell.cp(`${workingDir}/truffle.js`, `${coverageDir}/truffle.js`);
-
+   
   // Coverage network opts NOT specified: default to the development network w/ modified
   // port, gasLimit, gasPrice. Export the config object only.
   } else {
@@ -203,9 +196,7 @@ try {
   istanbulReporter.add('html');
   istanbulReporter.add('lcov');
   istanbulReporter.add('text');
-  istanbulReporter.write(istanbulCollector, true, () => {
-    log('Istanbul coverage reports generated');
-  });
+  istanbulReporter.write(istanbulCollector, true);
 } catch (err) {
   if (config.testing) {
     cleanUp();


### PR DESCRIPTION
Resolves #42.

Kind of copped out here but basically - if you're passing in a testrpc options string, you should specify a port there, & also set the .solcover.js port option, and your coverage network port should not conflict with these settings. Otherwise tool will break.  