### PR TITLE
Allow files to be skipped during coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ can be useful if you are using a different vm like the [sc-forks version of pyet
 directory. `dir` allows you to define a relative path from the root directory to those assets.
 `dir: "./<dirname>"` would tell solidity-coverage to look for `./<dirname>/contracts/` and `./<dirname>/test/`
 + **copyNodeModules**: *{ Boolean }* : When true, will copy `node_modules` into the coverage environment. False by default, and may significantly increase the time for coverage to complete if enabled. Only enable if required.
++ **skipFiles**: *{ Array }* : An array of contracts (with paths expressed relative to the `contracts` directory) that should be skipped when doing instrumentation. `Migrations.sol` is skipped by default, and does not need to be added to this configuration option if it is used.
 
 **Example .solcover.js config file**
 ```javascript
@@ -97,7 +98,7 @@ the extra events. If this is the case, then the coverage may be incomplete. To a
 
 **Using `require` in `migrations.js` files**: Truffle overloads Node's `require` function but
 implements a simplified search algorithm for node_modules packages
-([see Truffle issue #383](https://github.com/trufflesuite/truffle/issues/383)). 
+([see Truffle issue #383](https://github.com/trufflesuite/truffle/issues/383)).
 Because solidity-coverage copies an instrumented version of your project into a temporary folder, `require`
 statements handled by Truffle internally won't resolve correctly.  
 

--- a/test/cli.js
+++ b/test/cli.js
@@ -242,6 +242,28 @@ describe('cli', () => {
     collectGarbage();
   });
 
+  it('contracts are skipped: should generate coverage, cleanup & exit(0)', () => {
+    // Skip instrumentation of some contracts
+    assert(pathExists('./coverage') === false, 'should start without: coverage');
+    assert(pathExists('./coverage.json') === false, 'should start without: coverage.json');
+    const testConfig = Object.assign({}, config);
+
+    testConfig.skipFiles = ['Owned.sol'];
+    mock.installInheritanceTest(testConfig);
+
+    shell.exec(script);
+    assert(shell.error() === null, 'script should not error');
+
+    assert(pathExists('./coverage') === true, 'script should gen coverage folder');
+    assert(pathExists('./coverage.json') === true, 'script should gen coverage.json');
+
+    const produced = JSON.parse(fs.readFileSync('./coverage.json', 'utf8'));
+    const firstKey = Object.keys(produced)[0];
+    assert(Object.keys(produced).length === 1, 'coverage.json should only contain instrumentation for one contract');
+    assert(firstKey.substr(firstKey.length - 9) === 'Proxy.sol', 'coverage.json should only contain instrumentation for Proxy.sol');
+    collectGarbage();
+  });
+
   it('truffle tests failing: should generate coverage, cleanup & exit(1)', () => {
     assert(pathExists('./coverage') === false, 'should start without: coverage');
     assert(pathExists('./coverage.json') === false, 'should start without: coverage.json');


### PR DESCRIPTION
While ordinarily we shouldn't want to do this, it is possible to construct valid contracts using assembly that break when the coverage events are injected.

An example of such a contract is the [EtherRouter](https://github.com/ownage-ltd/ether-router/blob/master/contracts/EtherRouter.sol) contract by Peter Borah. It repeatedly calls `mload(0x40)` when it needs a memory address, as it only uses one piece of memory at a time and repeatedly overwrites the memory starting at the address contained in `0x40`. In Solidity, `0x40` is a special memory address that contains the address of the first empty slot. When events in solidity are compiled, they use the address contained in `0x40` and update it, and so the injected instrumentation events clobber the memory that `EtherRouter` is using.

This time, I've also included a test to demonstrate that skipping a contract works!

Really, this is just another sign pointing towards a huge do-over for `solidity-coverage` that I've been trying not to think about. Once `testrpc` allows [debug_traceTransaction](https://github.com/ethereumjs/testrpc/pull/282), we should *really* be using that functionality plus [source mappings](https://github.com/ethereum/solidity/blob/develop/docs/miscellaneous.rst#source-mappings) to generate coverage. We would no longer require a custom `testrpc`, wouldn't have to have to make our own coverage environment, no need for custom very high gas limits, or run in to these sorts of issues where instrumentation breaks contracts...

EDIT: I am a terrible collaborator. Just noticed #17 existed, and you wanted to do it a different way... I don't think that using comments is the way to go though. In some cases, I would expect the contracts that wanted to be ignored would be libraries that the user will not want to edit directly.