### PR TITLE
Instrument empty contract bodies correctly

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -46,13 +46,13 @@ parse.ContractStatement = function ParseContractStatement(contract, expression) 
 
 parse.ContractOrLibraryStatement = function parseContractOrLibraryStatement(contract, expression) {
   // From the start of this contract statement, find the first '{', and inject there.
-  const injectionPoint = expression.start + contract.instrumented.slice(expression.start).indexOf('{') + 2;
+  const injectionPoint = expression.start + contract.instrumented.slice(expression.start).indexOf('{') + 1;
   if (contract.injectionPoints[injectionPoint]) {
-    contract.injectionPoints[expression.start + contract.instrumented.slice(expression.start).indexOf('{') + 2].push({
+    contract.injectionPoints[expression.start + contract.instrumented.slice(expression.start).indexOf('{') + 1].push({
       type: 'eventDefinition',
     });
   } else {
-    contract.injectionPoints[expression.start + contract.instrumented.slice(expression.start).indexOf('{') + 2] = [{
+    contract.injectionPoints[expression.start + contract.instrumented.slice(expression.start).indexOf('{') + 1] = [{
       type: 'eventDefinition',
     }];
   }

--- a/test/sources/statements/empty-contract-ala-melonport.sol
+++ b/test/sources/statements/empty-contract-ala-melonport.sol
@@ -1,5 +1,3 @@
 pragma solidity ^0.4.3;
 
-contract Test {    
-}
-
+contract Test {}

--- a/test/statements.js
+++ b/test/statements.js
@@ -46,6 +46,14 @@ describe('generic statements', () => {
     const output = solc.compile(info.contract, 1);
     util.report(output.errors);
   });
+
+  it('should compile after instrumenting an empty-contract-body', () => {
+    const contract = util.getCode('statements/empty-contract-ala-melonport.sol');
+    const info = getInstrumentedVersion(contract, filePath);
+    const output = solc.compile(info.contract, 1);
+    util.report(output.errors);
+  });
+
   it('should cover a statement following a close brace', done => {
     const contract = util.getCode('statements/post-close-brace.sol');
     const info = getInstrumentedVersion(contract, filePath);


### PR DESCRIPTION
Slightly modifies the `ContractStatement` injection so that it can handle case where there is no whitespace between the opening and closing brackets of an empty contract declaration.  Adds a test.