### PR TITLE
Pin testrpc-sc to the 3.0.3 branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "commander": "^2.9.0",
     "death": "^1.1.0",
-    "ethereumjs-testrpc-sc": "https://github.com/sc-forks/testrpc-sc.git",
+    "ethereumjs-testrpc-sc": "https://github.com/sc-forks/testrpc-sc.git#303",
     "istanbul": "^0.4.5",
     "keccakjs": "^0.2.1",
     "mkdirp": "^0.5.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "commander": "^2.9.0",
     "death": "^1.1.0",
-    "ethereumjs-testrpc-sc": "https://github.com/sc-forks/testrpc-sc.git#303",
+    "ethereumjs-testrpc-sc": "https://github.com/sc-forks/testrpc-sc.git#3.0.3",
     "istanbul": "^0.4.5",
     "keccakjs": "^0.2.1",
     "mkdirp": "^0.5.1",


### PR DESCRIPTION
This is to provide a safe-haven we can revert to on npm while testrpc-sc is upgraded to v.4