### PR TITLE
Upgrade to ethereumjs-testrpc-4.0.1

### DIFF
--- a/docs/testrpc-sc.md
+++ b/docs/testrpc-sc.md
@@ -1,6 +1,6 @@
 # How to upgrade testrpc-sc
 
-Warning: this is a birds nest. Any ideas for improvement, however small, are welcome. Document may contain inaccuracies.
+Warning: this is a birds nest. Any ideas for improvement, however small, are welcome. 
 
 ### testrpc-sc:
 + published on `npm` as `ethereumjs-testrpc-sc`
@@ -18,7 +18,7 @@ $ yarn install
 $ npm run build       // Check build, just to make sure
 $ npm version patch   // If helpful. If you're tracking the upstream with a ganache-core sync, use theirs.
 $ git push
-$ npm publish         // This also runs build. Emphasizing the need to build here. 
+$ npm publish         // This also runs build.  
 
 // Go to `solidity-coverage` and pin its `testrpc-sc` dependency to the new version. 
 ```
@@ -26,7 +26,7 @@ $ npm publish         // This also runs build. Emphasizing the need to build her
 + is what testrpc-sc used to be
 + set by default to [its `coverage` branch](https://github.com/sc-forks/ganache-core-sc)
 + depends on `sc-forks/ethereumjs-vm-sc.git`
-+ depends on `sc-forks/provider-engine-sc.git#8.1.19` (Don't look too closely at this)
++ depends on `sc-forks/provider-engine-sc.git#8.1.19` 
 + differs from `truffle-suite/ganache-core` by these deps AND 
   [two lines](https://github.com/sc-forks/ganache-core/blob/ae31080cdc581fef416a1c68cbe28ff71b6fb7c9/lib/blockchain_double.js#L36-L37) 
   in `blockchain_double.js` which set the block and transaction default gas limits.
@@ -44,7 +44,7 @@ $ git push
 
 ### How can I modify ethereumjs-vm-sc and test the changes at `solidity-coverage`?
 
-It's a nightmare. You have to cut a channel of branches (say `#vm`) through the entire project:
+Cut a channel of branches (say `#vm`) through the entire project:
 
 `solidity-coverage#vm` with `package.json`
 ```
@@ -53,7 +53,7 @@ It's a nightmare. You have to cut a channel of branches (say `#vm`) through the 
 
 `testrpc-sc#vm` **based on the coverage branch** with `package.json`
 ```
-"ganache-core": "https://github.com/sc-forks/ganache-core.git#vm"
+"ganache-core": "https://github.com/sc-forks/ganache-core-sc.git#vm"
 ```
 
 `ganache-core#vm` with `package.json`

--- a/docs/testrpc-sc.md
+++ b/docs/testrpc-sc.md
@@ -1,0 +1,83 @@
+# How to upgrade testrpc-sc
+
+Warning: this is a birds nest. Any ideas for improvement, however small, are welcome. Document may contain inaccuracies.
+
+### testrpc-sc:
++ published on `npm` as `ethereumjs-testrpc-sc`
++ published **from the coverage branch** of [`sc-forks/testrpc-sc`](https://github.com/sc-forks/testrpc-sc/tree/coverage)
++ a webpack bundle of `sc-forks/ganache-core-sc#coverage` and all of its dependencies.
++ changing `sc-forks/ganache-core#coverage` or any of its dependencies cannot harm `testrpc-sc` (until publication)
++ publishing `testrpc-sc` cannot harm `solidity-coverage` until its deps are updated.
+
+To publish a new version:
+
+```
+$ git checkout coverage
+$ rm -rf node_modules
+$ yarn install
+$ npm run build       // Check build, just to make sure
+$ npm version patch   // If helpful. If you're tracking the upstream with a ganache-core sync, use theirs.
+$ git push
+$ npm publish         // This also runs build. Emphasizing the need to build here. 
+
+// Go to `solidity-coverage` and pin its `testrpc-sc` dependency to the new version. 
+```
+### sc-forks/ganache-core-sc:
++ is what testrpc-sc used to be
++ set by default to [its `coverage` branch](https://github.com/sc-forks/ganache-core-sc)
++ depends on `sc-forks/ethereumjs-vm-sc.git`
++ depends on `sc-forks/provider-engine-sc.git#8.1.19` (Don't look too closely at this)
++ differs from `truffle-suite/ganache-core` by these deps AND 
+  [two lines](https://github.com/sc-forks/ganache-core/blob/ae31080cdc581fef416a1c68cbe28ff71b6fb7c9/lib/blockchain_double.js#L36-L37) 
+  in `blockchain_double.js` which set the block and transaction default gas limits.
+
+To sync `ganache-core-sc` with its upstream parent at `truffle-suite`
+```
+$ git checkout master
+$ git remote add upstream https://github.com/trufflesuite/ganache-core.git
+$ git pull upstream master
+$ git push
+$ git checkout coverage 
+$ git rebase -i master (there will probably be conflicts)
+$ git push
+```
+
+### How can I modify ethereumjs-vm-sc and test the changes at `solidity-coverage`?
+
+It's a nightmare. You have to cut a channel of branches (say `#vm`) through the entire project:
+
+`solidity-coverage#vm` with `package.json`
+```
+"ethereumjs-testrpc-sc": "https://github.com/sc-forks/testrpc-sc.git#vm"
+```
+
+`testrpc-sc#vm` **based on the coverage branch** with `package.json`
+```
+"ganache-core": "https://github.com/sc-forks/ganache-core.git#vm"
+```
+
+`ganache-core#vm` with `package.json`
+```
+"ethereumjs-vm": "https://github.com/sc-forks/ethereumjs-vm-sc.git#vm"
+```
+
+`ethereumjs-vm-sc#vm` (This is where you will work).
+
++ To test your changes: 
+  + freshly install `node_modules` in testrpc-sc#vm and execute `npm run build` 
+  + freshly install `node_modules` in `solidity-coverage#vm`
+
+
++ To merge / publish the changes:
+  + Merge `ethereumjs-vm-sc#vm` to master.
+  + follow the `testrpc-sc` publication steps above.
+
+
+
+
+
+
+
+
+
+

--- a/lib/app.js
+++ b/lib/app.js
@@ -129,7 +129,7 @@ class App {
       if (!this.norpc) {
         const defaultRpcOptions = `--gasLimit ${gasLimitHex} --accounts ${this.accounts} --port ${this.port}`;
         const options = this.testrpcOptions || defaultRpcOptions;
-        const command = './node_modules/ethereumjs-testrpc-sc/bin/testrpc ';
+        const command = './node_modules/ethereumjs-testrpc-sc/build/cli.node.js ';
 
         // Launch
         this.testrpcProcess = childprocess.exec(command + options, null, (err, stdout, stderr) => {

--- a/package.json
+++ b/package.json
@@ -23,14 +23,15 @@
   "dependencies": {
     "commander": "^2.9.0",
     "death": "^1.1.0",
-    "ethereumjs-testrpc-sc": "https://github.com/sc-forks/testrpc-sc.git#3.0.3",
+    "ethereumjs-testrpc-sc": "git+https://github.com/sc-forks/testrpc-sc.git#coverage",
     "istanbul": "^0.4.5",
     "keccakjs": "^0.2.1",
     "mkdirp": "^0.5.1",
     "req-cwd": "^1.0.1",
     "shelljs": "^0.7.4",
     "sol-explore": "^1.6.2",
-    "solidity-parser": "git+https://github.com/sc-forks/solidity-parser.git"
+    "solidity-parser": "git+https://github.com/sc-forks/solidity-parser.git",
+    "web3": "^0.18.4"
   },
   "devDependencies": {
     "crypto-js": "^3.1.9-1",
@@ -39,13 +40,14 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-mocha": "^4.8.0",
     "ethereumjs-account": "~2.0.4",
-    "ethereumjs-vm": "https://github.com/sc-forks/ethereumjs-vm-sc.git#3.0.3",
     "ethereumjs-tx": "^1.2.2",
     "ethereumjs-util": "^5.0.1",
+    "ethereumjs-vm": "https://github.com/sc-forks/ethereumjs-vm-sc.git#3.0.3",
     "istanbul": "^0.4.5",
     "merkle-patricia-tree": "~2.1.2",
     "mocha": "^3.1.0",
     "solc": "0.4.13",
+    "request": "^2.81.0",
     "truffle": "3.4.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "commander": "^2.9.0",
     "death": "^1.1.0",
-    "ethereumjs-testrpc-sc": "git+https://github.com/sc-forks/testrpc-sc.git#coverage",
+    "ethereumjs-testrpc-sc": "4.0.1",
     "istanbul": "^0.4.5",
     "keccakjs": "^0.2.1",
     "mkdirp": "^0.5.1",
@@ -42,7 +42,7 @@
     "ethereumjs-account": "~2.0.4",
     "ethereumjs-tx": "^1.2.2",
     "ethereumjs-util": "^5.0.1",
-    "ethereumjs-vm": "https://github.com/sc-forks/ethereumjs-vm-sc.git#3.0.3",
+    "ethereumjs-vm": "https://github.com/sc-forks/ethereumjs-vm-sc.git",
     "istanbul": "^0.4.5",
     "merkle-patricia-tree": "~2.1.2",
     "mocha": "^3.1.0",


### PR DESCRIPTION
Resolves #64 

+ Includes the beginnings of a [guide to testrpc-sc publication / modification](https://github.com/sc-forks/solidity-coverage/blob/master/docs/testrpc-sc.md)
+ Upgrades to our own published version of [4.0.1](https://www.npmjs.com/package/ethereumjs-testrpc-sc)
+ Adds dependencies we were getting as part of the old testrpc including web3@^0.18.4
+ Changes the `node_modules` path we launch testrpc with as part of yarn compatibility, since that changed in v4.

In the end I decided to keep testrpc-sc `master` as it is and publish v4 from a `coverage` branch. In a month or something we could deprecate current master and start syncing it with its upstream parent. Then we can make the default branch `coverage`, periodically merging upstream changes into it.  Or whatever . . . once we start publishing on npm we can re-organize everything in whatever way makes sense.

It may be reasonable to publish this as a major version. The only thing that's really a breaking change is the path for people who are using the `norpc` option and are running testrpc-sc separately from the command line via the `node_modules` folder (like we are).  However that describes Open-Zeppelin and may describe others  as well. Before the testrpc race condition fix a couple weeks ago it was one of the only ways to get the tool to run consistently. 

Holding off on publishing in any case pending review / input.