### PR TITLE
Correctly instrument comments near function's {

### DIFF
--- a/lib/instrumenter.js
+++ b/lib/instrumenter.js
@@ -160,7 +160,6 @@ instrumenter.instrumentFunctionDeclaration = function instrumentFunctionDeclarat
   const startcol = expression.start - contract.instrumented.slice(0, expression.start).lastIndexOf('\n') - 1;
   const endlineDelta = contract.instrumented.slice(expression.start).indexOf('{');
   const functionDefinition = contract.instrumented.slice(expression.start, expression.start + endlineDelta);
-  const lastChar = contract.instrumented.slice(expression.start, expression.start + endlineDelta + 1).slice(-1);
   const endline = startline + (functionDefinition.match(/\n/g) || []).length;
   const endcol = functionDefinition.length - functionDefinition.lastIndexOf('\n');
   contract.fnMap[contract.fnId] = {
@@ -175,15 +174,9 @@ instrumenter.instrumentFunctionDeclaration = function instrumentFunctionDeclarat
       },
     },
   };
-  if (lastChar === '}') {
-    createOrAppendInjectionPoint(contract, expression.start + endlineDelta, {
-      type: 'callFunctionEvent', fnId: contract.fnId,
-    });
-  } else {
-    createOrAppendInjectionPoint(contract, expression.start + endlineDelta + 1, {
-      type: 'callFunctionEvent', fnId: contract.fnId,
-    });
-  }
+  createOrAppendInjectionPoint(contract, expression.start + endlineDelta + 1, {
+    type: 'callFunctionEvent', fnId: contract.fnId,
+  });
 };
 
 instrumenter.addNewBranch = function addNewBranch(contract, expression) {

--- a/lib/instrumenter.js
+++ b/lib/instrumenter.js
@@ -158,7 +158,7 @@ instrumenter.instrumentFunctionDeclaration = function instrumentFunctionDeclarat
   const startline = (contract.instrumented.slice(0, expression.start).match(/\n/g) || []).length + 1;
   // We need to work out the lines and columns the function declaration starts and ends
   const startcol = expression.start - contract.instrumented.slice(0, expression.start).lastIndexOf('\n') - 1;
-  const endlineDelta = contract.instrumented.slice(expression.start).indexOf('{') + 1;
+  const endlineDelta = contract.instrumented.slice(expression.start).indexOf('{');
   const functionDefinition = contract.instrumented.slice(expression.start, expression.start + endlineDelta);
   const lastChar = contract.instrumented.slice(expression.start, expression.start + endlineDelta + 1).slice(-1);
   const endline = startline + (functionDefinition.match(/\n/g) || []).length;

--- a/test/comments.js
+++ b/test/comments.js
@@ -1,0 +1,36 @@
+/* eslint-env node, mocha */
+
+const path = require('path');
+const getInstrumentedVersion = require('./../lib/instrumentSolidity.js');
+const util = require('./util/util.js');
+const solc = require('solc');
+
+describe('comments', () => {
+  const filePath = path.resolve('./test.sol');
+  const pathPrefix = './';
+
+  it('should cover functions even if comments are present immediately after the opening {', () => {
+    const contract = util.getCode('comments/postFunctionDeclarationComment.sol');
+    const info = getInstrumentedVersion(contract, filePath);
+    const output = solc.compile(info.contract, 1);
+    util.report(output.errors);
+  });
+  it('should cover lines even if comments are present', () => {
+    const contract = util.getCode('comments/postLineComment.sol');
+    const info = getInstrumentedVersion(contract, filePath);
+    const output = solc.compile(info.contract, 1);
+    util.report(output.errors);
+  });
+  it('should cover contracts even if comments are present', () => {
+    const contract = util.getCode('comments/postContractComment.sol');
+    const info = getInstrumentedVersion(contract, filePath);
+    const output = solc.compile(info.contract, 1);
+    util.report(output.errors);
+  });
+  it('should cover if statements even if comments are present immediately after opening { ', () => {
+    const contract = util.getCode('comments/postIfStatementComment.sol');
+    const info = getInstrumentedVersion(contract, filePath);
+    const output = solc.compile(info.contract, 1);
+    util.report(output.errors);
+  });
+});

--- a/test/sources/comments/postContractComment.sol
+++ b/test/sources/comments/postContractComment.sol
@@ -1,0 +1,8 @@
+pragma solidity ^0.4.13;
+
+contract Test {//Comment immediately after contract declaration
+  function a(bool test){
+    var x = 1;
+    var y = 2;
+  }
+}

--- a/test/sources/comments/postFunctionDeclarationComment.sol
+++ b/test/sources/comments/postFunctionDeclarationComment.sol
@@ -1,0 +1,7 @@
+pragma solidity ^0.4.13;
+
+contract Test {
+  function a(bool test){//Comment immediately after function declaration
+  }
+  function b(bool test){var x=1;}//Comment immediately after function closes
+}

--- a/test/sources/comments/postIfStatementComment.sol
+++ b/test/sources/comments/postIfStatementComment.sol
@@ -1,0 +1,12 @@
+pragma solidity ^0.4.13;
+
+contract Test {
+  function a(bool x){
+    int y;
+    if (x){//Comment straight after {
+      y = 1;
+    }else{//Comment straight after {
+      y = 2;
+    }
+  }
+}

--- a/test/sources/comments/postLineComment.sol
+++ b/test/sources/comments/postLineComment.sol
@@ -1,0 +1,8 @@
+pragma solidity ^0.4.13;
+
+contract Test {
+  function a(bool test){
+    var x = 1;//Comment immediately after line
+    var y = 2;
+  }
+}


### PR DESCRIPTION
Fix the off-by-one-error discovered with comments immediately following function declarations. Also added tests to check that we didn't have similar issues with other statements / declarations.

Fixes #88 
