### PR TITLE
Allow truffle.js to be named truffle-config.js

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -66,7 +66,12 @@ class App {
       shell.mkdir(this.coverageDir);
       shell.cp('-R', files, this.coverageDir);
 
-      const truffleConfig = reqCwd.silent(`${this.workingDir}/truffle.js`);
+      // Load config if present, accomodate common windows naming.
+      let truffleConfig;
+      
+      shell.test('-e', `${this.workingDir}/truffle.js`)
+          ? truffleConfig = reqCwd.silent(`${this.workingDir}/truffle.js`)
+          : truffleConfig = reqCwd.silent(`${this.workingDir}/truffle-config.js`);
 
       // Coverage network opts specified: use port if declared
       if (truffleConfig && truffleConfig.networks && truffleConfig.networks.coverage) {
@@ -76,7 +81,10 @@ class App {
       // No coverage network defaults to the dev network on port 8555, high gas / low price.
       } else {
         const trufflejs = defaultTruffleConfig(this.port, gasLimitHex, gasPriceHex);
-        fs.writeFileSync(`${this.coverageDir}/truffle.js`, trufflejs);
+
+        (process.platform === 'win32')
+          ? fs.writeFileSync(`${this.coverageDir}/truffle-config.js`, trufflejs)
+          : fs.writeFileSync(`${this.coverageDir}/truffle.js`, trufflejs);
       }
     } catch (err) {
       const msg = ('There was a problem generating the coverage environment: ');

--- a/test/app.js
+++ b/test/app.js
@@ -209,6 +209,29 @@ describe('app', () => {
     collectGarbage();
   });
 
+  it('project uses truffle-config.js: should generate coverage, cleanup and exit(0)', () => {  
+    // Directory should be clean
+    assert(pathExists('./coverage') === false, 'should start without: coverage');
+    assert(pathExists('./coverage.json') === false, 'should start without: coverage.json');
+
+    // Run script (exits 0);
+    mock.install('Simple.sol', 'simple.js', config, null, 'truffle-config.js');
+    shell.exec(script);
+    assert(shell.error() === null, 'script should not error');
+
+    // Directory should have coverage report
+    assert(pathExists('./coverage') === true, 'script should gen coverage folder');
+    assert(pathExists('./coverage.json') === true, 'script should gen coverage.json');
+
+    // Coverage should be real.
+    // This test is tightly bound to the function names in Simple.sol
+    const produced = JSON.parse(fs.readFileSync('./coverage.json', 'utf8'));
+    const path = Object.keys(produced)[0];
+    assert(produced[path].fnMap['1'].name === 'test', 'coverage.json should map "test"');
+    assert(produced[path].fnMap['2'].name === 'getX', 'coverage.json should map "getX"');
+    collectGarbage();
+  });
+
   it('testrpc-sc signs and recovers messages correctly', () => {
     // sign.js signs and recovers
     mock.install('Simple.sol', 'sign.js', config);

--- a/test/util/mockTruffle.js
+++ b/test/util/mockTruffle.js
@@ -12,9 +12,10 @@ const shell = require('shelljs');
  * @param  {String} contract <contractName.sol> located in /test/sources/cli/
  * @param  {[type]} test     <testName.js> located in /test/cli/
  */
-module.exports.install = function install(contract, test, config, _trufflejs) {
+module.exports.install = function install(contract, test, config, _trufflejs, _trufflejsName) {
   const configjs = `module.exports = ${JSON.stringify(config)}`;
   const contractLocation = `./${contract}`;
+  const trufflejsName = _trufflejsName || 'truffle.js'; 
 
   // Mock migrations
   const initialMigration = `
@@ -64,7 +65,7 @@ module.exports.install = function install(contract, test, config, _trufflejs) {
   shell.cp('./test/sources/cli/Migrations.sol', './mock/contracts/Migrations.sol');
   fs.writeFileSync('./mock/migrations/1_initial_migration.js', initialMigration);
   fs.writeFileSync('./mock/migrations/2_deploy_contracts.js', deployContracts);
-  fs.writeFileSync('./mock/truffle.js', trufflejs);
+  fs.writeFileSync(`./mock/${trufflejsName}`, trufflejs);
   fs.writeFileSync('./mock/assets/asset.js', asset);
   fs.writeFileSync('./.solcover.js', configjs);
   shell.cp(`./test/cli/${test}`, `./mock/test/${test}`);


### PR DESCRIPTION
Resolves #93.

+ Checks for existence of alternate truffle.js named `truffle-config.js` (windows issue).
+ Names stub truffle config file `truffle-config.js` when platform is windows. 
+ Adds test for alternate file name.