### PR TITLE
Register sigint handler immediately

### DIFF
--- a/bin/exec.js
+++ b/bin/exec.js
@@ -8,6 +8,8 @@ const log = console.log;
 const config = reqCwd.silent('./.solcover.js') || {};
 const app = new App(config);
 
+death((signal, err) => app.cleanUp(err));
+
 app.generateCoverageEnvironment();
 app.instrumentTarget();
 app.launchTestrpc()
@@ -17,5 +19,5 @@ app.launchTestrpc()
   })
   .catch(err => log(err));
 
-death((signal, err) => app.cleanUp(err));
+
 


### PR DESCRIPTION
Fixes a failure to register the sigint handler before we generate the `coverageEnv` and instrument the project.  People who hit `ctrl-c` during that phase of the run were left with debris in the repo which confused subsequent runs of the tool.

Resolves #113.

Thanks @nberger for description and solution.