### PR TITLE
Revert vm stipend fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Solutions to common issues people run into using this tool:
 + [Using alongside HDWalletProvider](https://github.com/sc-forks/solidity-coverage/blob/master/docs/faq.md#using-alongside-hdwalletprovider)
 + [Integrating into CI](https://github.com/sc-forks/solidity-coverage/blob/master/docs/faq.md#continuous-integration-installing-metacoin-on-travisci-with-coveralls)
 + [Why are asserts and requires highlighted as branch points?](https://github.com/sc-forks/solidity-coverage/blob/master/docs/faq.md#why-has-my-branch-coverage-decreased-why-is-assert-being-shown-as-a-branch-point)
++ [Why are `send` and `transfer` throwing in my tests?](https://github.com/sc-forks/solidity-coverage/blob/master/docs/faq.md#why-are-send-and-transfer-throwing)
 + [Running testrpc-sc on its own](https://github.com/sc-forks/solidity-coverage/blob/master/docs/faq.md#running-testrpc-sc-on-its-own)
 
 ### Example reports 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -170,6 +170,12 @@ Clearly, the coverage should be the same in these situations, as the code is (fu
 
 If an `assert` or `require` is marked with an `I` in the coverage report, then during your tests the conditional is never true. If it is marked with an `E`, then it is never false.
 
+### Why are send and transfer throwing?
+
+If you include contracts that have fallback function in the list of files to instrument and attempt to `send` or `transfer` to them,
+the methods will throw because the instrumentation consumes more gas than these methods allow. See the `skipFiles` option in the 
+README to exclude these files and [issue 118](https://github.com/sc-forks/solidity-coverage/issues/118) for a more detailed discussion of
+this problem.
 
 ### Running testrpc-sc on its own
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "commander": "^2.9.0",
     "death": "^1.1.0",
-    "ethereumjs-testrpc-sc": "4.0.3",
+    "ethereumjs-testrpc-sc": "4.0.2",
     "istanbul": "^0.4.5",
     "keccakjs": "^0.2.1",
     "mkdirp": "^0.5.1",

--- a/test/app.js
+++ b/test/app.js
@@ -281,7 +281,7 @@ describe('app', () => {
     collectGarbage();
   });
 
-  it('contract sends / transfers to instrumented fallback: coverage, cleanup & exit(0)', () => {
+  it.skip('contract sends / transfers to instrumented fallback: coverage, cleanup & exit(0)', () => {
     // Validate ethereumjs-vm hack to remove gas constraints on transfer() and send()
     assert(pathExists('./coverage') === false, 'should start without: coverage');
     assert(pathExists('./coverage.json') === false, 'should start without: coverage.json');


### PR DESCRIPTION
Resolves #118 at the cost of re-opening #106. 

Stipend is free and you can't just make it 230000 - calling accounts will get refunded gas that was never debited from them. Bumping `testrpc-sc` down to pre-stipend version and adding some notes to the docs.