### PR TITLE
Increase testrpc-sc stdout buffer size

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -153,7 +153,8 @@ class App {
           : command = `${npm} `;
 
         // Launch
-        this.testrpcProcess = childprocess.exec(command + options, null, (err, stdout, stderr) => {
+        const execOpts = {maxBuffer: 1024 * 1024 * 10};
+        this.testrpcProcess = childprocess.exec(command + options, execOpts, (err, stdout, stderr) => {
           if (err) {
             if (stdout) this.log(`testRpc stdout:\n${stdout}`);
             if (stderr) this.log(`testRpc stderr:\n${stderr}`);


### PR DESCRIPTION
Resolves bug reported and fixed by @rudolfix at #120. All credit to them. 

Without this large test suites will max out the stdout buffer using the internally launced testrpc.