### PR TITLE
npm publishing solidity-parser-sc

### DIFF
--- a/docs/testrpc-sc.md
+++ b/docs/testrpc-sc.md
@@ -1,6 +1,6 @@
 # How to upgrade testrpc-sc
 
-Warning: this is a birds nest. Any ideas for improvement, however small, are welcome. 
+Warning: this is a birds nest. Any ideas for improvement, however small, are welcome.
 
 ### testrpc-sc:
 + published on `npm` as `ethereumjs-testrpc-sc`
@@ -18,17 +18,17 @@ $ yarn install
 $ npm run build       // Check build, just to make sure
 $ npm version patch   // If helpful. If you're tracking the upstream with a ganache-core sync, use theirs.
 $ git push
-$ npm publish         // This also runs build.  
+$ npm publish         // This also runs build.
 
-// Go to `solidity-coverage` and pin its `testrpc-sc` dependency to the new version. 
+// Go to `solidity-coverage` and pin its `testrpc-sc` dependency to the new version.
 ```
 ### sc-forks/ganache-core-sc:
 + is what testrpc-sc used to be
 + set by default to [its `coverage` branch](https://github.com/sc-forks/ganache-core-sc)
 + depends on `sc-forks/ethereumjs-vm-sc.git`
-+ depends on `sc-forks/provider-engine-sc.git#8.1.19` 
-+ differs from `truffle-suite/ganache-core` by these deps and 
-  [two lines](https://github.com/sc-forks/ganache-core/blob/ae31080cdc581fef416a1c68cbe28ff71b6fb7c9/lib/blockchain_double.js#L36-L37) 
++ depends on `sc-forks/provider-engine-sc.git#8.1.19`
++ differs from `truffle-suite/ganache-core` by these deps and
+  [two lines](https://github.com/sc-forks/ganache-core/blob/ae31080cdc581fef416a1c68cbe28ff71b6fb7c9/lib/blockchain_double.js#L36-L37)
   in `blockchain_double.js` which set the block and transaction default gas limits.
 
 To sync `ganache-core-sc` with its upstream parent at `truffle-suite`
@@ -37,17 +37,17 @@ $ git checkout master
 $ git remote add upstream https://github.com/trufflesuite/ganache-core.git
 $ git pull upstream master
 $ git push
-$ git checkout coverage 
+$ git checkout coverage
 $ git rebase -i master (there will probably be conflicts)
 $ git push
 ```
 
 ### How can I modify ethereumjs-vm-sc and test the changes at `solidity-coverage`?
 
-Since `solidity-coverage@0.1.10`, ethereumjs-vm-sc is an independent dev dependency, 
-required by the coverage unit tests. The new testrpc has a separate webpacked copy. The simplest 
-thing to do is open a branch at `solidity-coverage` and develop directly on the `vm` dep. 
-When you're satisfied that tests pass with your changes, copy your work over to the `ethereumjs-vm-sc` repo itself. 
+Since `solidity-coverage@0.1.10`, ethereumjs-vm-sc is an independent dev dependency,
+required by the coverage unit tests. The new testrpc has a separate webpacked copy. The simplest
+thing to do is open a branch at `solidity-coverage` and develop directly on the `vm` dep.
+When you're satisfied that tests pass with your changes, copy your work over to the `ethereumjs-vm-sc` repo itself.
 
 In `test/util/vm.js` the `results` object passed back by `vm.runTx` at [callMethod](https://github.com/sc-forks/solidity-coverage/blob/master/test/util/vm.js#L120)
 also contains things like the runState and the logs: ex: `results.vm.runState.logs`.
@@ -57,18 +57,22 @@ also contains things like the runState and the logs: ex: `results.vm.runState.lo
   + follow the `testrpc-sc` publication steps above.
 
 There's no reason to worry about changing ethereumjs-vm-sc at master. If that affects anyone (unlikely)
-they have safe harbour at any solidity-coverage installation @0.1.9 and up. They can update. 
+they have safe harbour at any solidity-coverage installation @0.1.9 and up. They can update.
 
 ### E2E Testing
 
-[sc-forks/zeppelin-solidity](https://github.com/sc-forks/zeppelin-solidity) has been configured to 
-serve as a simple pre-publication E2E test. By default the package pulls solidity-coverage from the repo's master branch. 
+[sc-forks/zeppelin-solidity](https://github.com/sc-forks/zeppelin-solidity) has been configured to
+serve as a simple pre-publication E2E test. By default the package pulls solidity-coverage from the repo's master branch.
 You can trigger a [CI build](https://travis-ci.org/sc-forks/zeppelin-solidity) and [Coveralls report](https://coveralls.io/github/sc-forks/zeppelin-solidity) by running:
 
 ```
 $ npm run ci
 ```
 
+### solidity-parser-sc
+
+We also publish `solidity-parser-sc` because `consensys/solidity-parser` in its .pegjs form has been
+left to die in the wild, unloved by all. Publish at the publish branch by running `npm version patch`, `npm publish`.
 
 
 

--- a/lib/instrumentSolidity.js
+++ b/lib/instrumentSolidity.js
@@ -1,4 +1,4 @@
-const SolidityParser = require('solidity-parser');
+const SolidityParser = require('solidity-parser-sc');
 const preprocessor = require('./preprocessor');
 const injector = require('./injector');
 const parse = require('./parse');

--- a/lib/preprocessor.js
+++ b/lib/preprocessor.js
@@ -1,5 +1,5 @@
 const SolExplore = require('sol-explore');
-const SolidityParser = require('solidity-parser');
+const SolidityParser = require('solidity-parser-sc');
 
 /**
  * Splices enclosing brackets into `contract` around `expression`;

--- a/package-lock.json
+++ b/package-lock.json
@@ -931,9 +931,9 @@
       "dev": true
     },
     "browserify-aes": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.8.tgz",
-      "integrity": "sha512-WYCMOT/PtGTlpOKFht0YJFYcPy6pLCR98CtWfzK13zoynLlBMvAdEMSRGmgnJCw2M2j/5qxBkinZQFobieM8dQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.1.0.tgz",
+      "integrity": "sha512-W2bIMLYoZ9oow7TyePpMJk9l9LY7O3R61a/68bVCDOtnJynnwe3ZeW2IzzSkrQnPKNdJrxVDn3ALZNisSBwb7g==",
       "requires": {
         "buffer-xor": "1.0.3",
         "cipher-base": "1.0.4",
@@ -948,7 +948,7 @@
       "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.0.tgz",
       "integrity": "sha1-mYgkSHS/XtTijalWZtzWasj8Njo=",
       "requires": {
-        "browserify-aes": "1.0.8",
+        "browserify-aes": "1.1.0",
         "browserify-des": "1.0.0",
         "evp_bytestokey": "1.0.3"
       }
@@ -1463,7 +1463,7 @@
       "integrity": "sha1-Pja2xCs3BDgjzbwzLVjzHiRFSAs=",
       "dev": true,
       "requires": {
-        "browserify-aes": "1.0.8",
+        "browserify-aes": "1.1.0",
         "create-hash": "1.1.3",
         "create-hmac": "1.1.6"
       }
@@ -1951,7 +1951,7 @@
       "resolved": "https://registry.npmjs.org/ethereumjs-testrpc-sc/-/ethereumjs-testrpc-sc-4.0.2.tgz",
       "integrity": "sha512-Gp/0/4cAH2g1rpcjiCngdxg7j6BKuFrvE1kWGSmnLjhRlbm1UW9/k923PbHKFIRP7oXMMio/lVeXAVsZZCEnrQ==",
       "requires": {
-        "webpack": "3.7.0"
+        "webpack": "3.7.1"
       }
     },
     "ethereumjs-tx": {
@@ -4663,7 +4663,7 @@
       "integrity": "sha1-N8T5t+06tlx0gXtfJICTf7+XxxI=",
       "requires": {
         "asn1.js": "4.9.1",
-        "browserify-aes": "1.0.8",
+        "browserify-aes": "1.1.0",
         "create-hash": "1.1.3",
         "evp_bytestokey": "1.0.3",
         "pbkdf2": "3.0.14"
@@ -5617,8 +5617,10 @@
         }
       }
     },
-    "solidity-parser": {
-      "version": "git+https://github.com/sc-forks/solidity-parser.git#8f3e1263d11705195a40f6390ad3276d8c853d88",
+    "solidity-parser-sc": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/solidity-parser-sc/-/solidity-parser-sc-0.4.1.tgz",
+      "integrity": "sha512-51kDgZXLCfgOtmxrPPK1Jhgi257emdf8g9xBA7BA5TgFTM8tSEgRzvJGlGTPbI03txLETuSvNpPhy46c+srOyQ==",
       "requires": {
         "mocha": "2.5.3",
         "pegjs": "0.10.0",
@@ -6297,9 +6299,9 @@
       }
     },
     "webpack": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-3.7.0.tgz",
-      "integrity": "sha512-+OKXJj9uqXDQQy6/poZuYRjCiQPPeXdiPpZmBupfDyMUAeqL+67jzCSxGJ9jok3c6Wy3nDivcjMbiVOcTgg8zg==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-3.7.1.tgz",
+      "integrity": "sha512-8MR+gVfxsvtx4J1UlbRGkUJEpDQUBFmisRmpPO5cVLgF21R8UMChX39OOjDz63a+m/iswGoqATszdZB2VCsYuA==",
       "requires": {
         "acorn": "5.1.2",
         "acorn-dynamic-import": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "req-cwd": "^1.0.1",
     "shelljs": "^0.7.4",
     "sol-explore": "^1.6.2",
-    "solidity-parser": "git+https://github.com/sc-forks/solidity-parser.git",
+    "solidity-parser-sc": "0.4.1",
     "web3": "^0.18.4"
   },
   "devDependencies": {


### PR DESCRIPTION
Tried to use `solparse` but there was a failing test that looked like it was caused by a discrepancy in whitespace handling at some rule? Or maybe start/end pos. 

Now more yarn compatible. 

#128 

