### PR TITLE
Do not preprocess view and constant

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -285,14 +285,10 @@ class App {
   postProcessPure(env) {
     shell.ls(`${env}/**/*.sol`).forEach(file => {
       const pureRe = /\spure\s/gi;
-      const viewRe = /\sview\s/gi;
-      const constantRe = /\sconstant\s/gi;
 
       const contractPath = this.platformNeutralPath(file);
       let contract = fs.readFileSync(contractPath).toString();
       contract = contract.replace(pureRe, ' ');
-      contract = contract.replace(viewRe, ' ');
-      contract = contract.replace(constantRe, ' ');
       fs.writeFileSync(contractPath, contract);
     })
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1963,7 +1963,7 @@
       }
     },
     "ethereumjs-vm": {
-      "version": "git+https://github.com/sc-forks/ethereumjs-vm-sc.git#a5f797299d0e96214af739be3bea4d0e15499c0d",
+      "version": "git+https://github.com/sc-forks/ethereumjs-vm-sc.git#6be86e6f12634b711423203e6744cafe07c38e69",
       "dev": true,
       "requires": {
         "async": "2.6.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "ethereumjs-account": "~2.0.4",
     "ethereumjs-tx": "^1.2.2",
     "ethereumjs-util": "^5.0.1",
-    "ethereumjs-vm": "https://github.com/sc-forks/ethereumjs-vm-sc.git#a5f797299d0e96214af739be3bea4d0e15499c0d",
+    "ethereumjs-vm": "https://github.com/sc-forks/ethereumjs-vm-sc.git#6be86e6f12634b711423203e6744cafe07c38e69",
     "merkle-patricia-tree": "~2.1.2",
     "mocha": "^3.1.0",
     "request": "^2.81.0",

--- a/package.json
+++ b/package.json
@@ -43,8 +43,8 @@
     "ethereumjs-vm": "https://github.com/sc-forks/ethereumjs-vm-sc.git#a5f797299d0e96214af739be3bea4d0e15499c0d",
     "merkle-patricia-tree": "~2.1.2",
     "mocha": "^3.1.0",
-    "solc": "0.4.17",
     "request": "^2.81.0",
+    "solc": "0.4.17",
     "truffle": "4.0.0-beta.2"
   }
 }

--- a/test/sources/cli/PureView.sol
+++ b/test/sources/cli/PureView.sol
@@ -1,4 +1,5 @@
-pragma experimental "v0.5.0";
+//pragma experimental "v0.5.0";
+pragma solidity ^0.4.17;
 
 contract PureView {
 

--- a/test/sources/cli/TotallyPure.sol
+++ b/test/sources/cli/TotallyPure.sol
@@ -1,4 +1,5 @@
-pragma experimental "v0.5.0";
+//pragma experimental "v0.5.0";
+pragma solidity ^0.4.17;
 
 import "./../assets/PureView.sol";
 


### PR DESCRIPTION
Somewhat belatedly realised that stripping off these modifiers changes their behavior. Constant / View and Pure return values not transaction objects. 

We're really getting squeezed into a corner here, EOL. 