### PR TITLE
Handle *.sol files that are invalid Solidity

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -286,9 +286,15 @@ class App {
   postProcessPure(env) {
     shell.ls(`${env}/**/*.sol`).forEach(file => {
       const contractPath = this.platformNeutralPath(file);
-      let contract = fs.readFileSync(contractPath).toString();
-      contract = preprocessor.run(contract);
-      fs.writeFileSync(contractPath, contract);
+      const contract = fs.readFileSync(contractPath).toString();
+      const contractProcessed = preprocessor.run(contract);
+      if (contractProcessed.name && contractProcessed.name === 'SyntaxError' && file.slice(-15) !== 'SimpleError.sol') {
+        console.log(`Warning: The file at ${file} was identified as a Solidity Contract, ` +
+         'but did not parse correctly. You may ignore this warning if it is not a Solidity file, ' +
+         'or your project does not use it');
+      } else {
+        fs.writeFileSync(contractPath, contractProcessed);
+      }
     });
   }
 

--- a/lib/preprocessor.js
+++ b/lib/preprocessor.js
@@ -26,42 +26,47 @@ module.exports.run = function r(contract) {
   let keepRunning = true;
 
   while (keepRunning) {
-    const ast = SolidityParser.parse(contract);
-    keepRunning = false;
-    SolExplore.traverse(ast, {
-      enter(node, parent) { // eslint-disable-line no-loop-func
-        // If consequents
-        if (node.type === 'IfStatement' && node.consequent.type !== 'BlockStatement') {
-          contract = blockWrap(contract, node.consequent);
-          keepRunning = true;
-          this.stopTraversal();
-        // If alternates
-        } else if (
-            node.type === 'IfStatement' &&
-            node.alternate &&
-            node.alternate.type !== 'BlockStatement') {
-          contract = blockWrap(contract, node.alternate);
-          keepRunning = true;
-          this.stopTraversal();
-        // Loops
-        } else if (
-            (node.type === 'ForStatement' || node.type === 'WhileStatement') &&
-            node.body.type !== 'BlockStatement') {
-          contract = blockWrap(contract, node.body);
-          keepRunning = true;
-          this.stopTraversal();
-        } else if (node.type === 'FunctionDeclaration' && node.modifiers) {
-          // We want to remove constant / pure / view from functions
-          for (let i = 0; i < node.modifiers.length; i++) {
-            if (['pure', 'constant', 'view'].indexOf(node.modifiers[i].name) > -1) {
-              contract = contract.slice(0, node.modifiers[i].start) + contract.slice(node.modifiers[i].end);
-              keepRunning = true;
-              this.stopTraversal();
+    try {
+      const ast = SolidityParser.parse(contract);
+      keepRunning = false;
+      SolExplore.traverse(ast, {
+        enter(node, parent) { // eslint-disable-line no-loop-func
+          // If consequents
+          if (node.type === 'IfStatement' && node.consequent.type !== 'BlockStatement') {
+            contract = blockWrap(contract, node.consequent);
+            keepRunning = true;
+            this.stopTraversal();
+          // If alternates
+          } else if (
+              node.type === 'IfStatement' &&
+              node.alternate &&
+              node.alternate.type !== 'BlockStatement') {
+            contract = blockWrap(contract, node.alternate);
+            keepRunning = true;
+            this.stopTraversal();
+          // Loops
+          } else if (
+              (node.type === 'ForStatement' || node.type === 'WhileStatement') &&
+              node.body.type !== 'BlockStatement') {
+            contract = blockWrap(contract, node.body);
+            keepRunning = true;
+            this.stopTraversal();
+          } else if (node.type === 'FunctionDeclaration' && node.modifiers) {
+            // We want to remove constant / pure / view from functions
+            for (let i = 0; i < node.modifiers.length; i++) {
+              if (['pure', 'constant', 'view'].indexOf(node.modifiers[i].name) > -1) {
+                contract = contract.slice(0, node.modifiers[i].start) + contract.slice(node.modifiers[i].end);
+                keepRunning = true;
+                this.stopTraversal();
+              }
             }
           }
-        }
-      },
-    });
+        },
+      });
+    } catch (err) {
+      contract = err;
+      keepRunning = false;
+    }
   }
   return contract;
 };

--- a/test/util/mockTruffle.js
+++ b/test/util/mockTruffle.js
@@ -51,6 +51,7 @@ module.exports.install = function install(contract, test, config, _trufflejs, _t
   shell.mkdir('./mock/contracts');
   shell.mkdir('./mock/migrations');
   shell.mkdir('./mock/assets');
+  shell.cp('./test/sources/cli/SimpleError.sol', './mock/assets/SimpleError.sol');
   shell.mkdir('./mock/node_modules');
   shell.mkdir('./mock/test');
 


### PR DESCRIPTION
I introduced a nice bug in #147 which this fixes. In order to remove `constant` from all functions for instrumentation to take place, including those imported from `./node_modules`, I ran the (increasingly badly named...) preprocessor over all `.sol` files that we find in the tree. Unfortunately, if we're using `copyNodeModules:true`, then that includes the `solidity-coverage` repository, which includes [SimpleError.sol](https://github.com/sc-forks/solidity-coverage/blob/4c2c9e5e994d44cda3fb39f0359f06a8531ebf88/test/sources/cli/SimpleError.sol), which deliberately has a syntax error in it! This caused an uncaught error to be thrown, and `solidity-coverage` to fail to run.

I did think about just skipping `SimpleError.sol` itself, but don't want to be in the position where we break if any other package installed uses `.sol` files that aren't Solidity. I therefore leave any `*.sol` files that fail to parse alone, and generate a warning in case this is unexpected by the user. `SimpleError.sol` is now added to the truffle mock in order to prevent a regression along these lines.

Fixes #155 