### PR TITLE
Significantly improves coverage time, specially for large projects.

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ module.exports = {
     testCommand: 'mocha --timeout 5000',
     norpc: true,
     dir: './secretDirectory',
+    copyPackages: ['zeppelin-solidity'],
     skipFiles: ['Routers/EtherRouter.sol']
 };
 ```
@@ -94,6 +95,7 @@ module.exports = {
 | testCommand | *String* | `truffle test` |  Run an arbitrary test command. ex: `mocha --timeout 5000`. NB: Also set the `port` option to whatever your tests require (probably 8545). |
 | testrpcOptions | *String* | `--port 8555` | options to append to a command line invocation of testrpc. NB: Using this overwrites the defaults so always specify a port in this string *and* in the `port` option |
 | copyNodeModules | *Boolean* | false | Copies `node_modules` into the coverage environment. May significantly increase the time for coverage to complete if enabled. Useful if your contracts import solidity files from an npm installed package. |
+| copyPackages | *Array* | `[]` | Copies specific `node_modules` packages into the coverage environment. May significantly reduce the time for coverage to complete compared to `copyNodeModules`. Useful if your contracts import solidity files from an npm installed package. |
 | skipFiles | *Array* | `['Migrations.sol']` | Array of contracts (with paths expressed relative to the `contracts` directory) that should be skipped when doing instrumentation. `Migrations.sol` is skipped by default, and does not need to be added to this configuration option if it is used. |
 | dir | *String* | `.` | Solidity-coverage copies all the assets in your root directory (except `node_modules`) to a special folder where it instruments the contracts and executes the tests. `dir` allows you to define a relative path from the root directory to those assets. Useful if your contracts & tests are within their own folder as part of a larger project.|
 

--- a/lib/app.js
+++ b/lib/app.js
@@ -76,7 +76,7 @@ class App {
       // Add specific node_modules packages.
       if (!this.copyNodeModules && this.copyPackages.length) {
         shell.mkdir(this.coverageDir + '/node_modules');
-        this.copyNodeModulesPackages.forEach((nodePackage) => {
+        this.copyPackages.forEach((nodePackage) => {
           shell.cp('-rf', 'node_modules/' + nodePackage, this.coverageDir + '/node_modules/');
         });
       }

--- a/lib/app.js
+++ b/lib/app.js
@@ -42,6 +42,7 @@ class App {
     this.port = config.port || 8555;             // Port testrpc should listen on
 
     this.copyNodeModules = config.copyNodeModules || false;  // Copy node modules into coverageEnv?
+    this.copyPackages = config.copyPackages || [];           // Only copy specific node_modules packages into coverageEnv
     this.testrpcOptions = config.testrpcOptions || null;     // Options for testrpc-sc
     this.testCommand = config.testCommand || null;           // Optional test command
 
@@ -71,6 +72,14 @@ class App {
       files = files.map(file => `${this.workingDir}/${file}`);
       shell.mkdir(this.coverageDir);
       shell.cp('-R', files, this.coverageDir);
+
+      // Add specific node_modules packages.
+      if (!this.copyNodeModules && this.copyPackages.length) {
+        shell.mkdir(this.coverageDir + '/node_modules');
+        this.copyNodeModulesPackages.forEach((nodePackage) => {
+          shell.cp('-rf', 'node_modules/' + nodePackage, this.coverageDir + '/node_modules/');
+        });
+      }
 
       // Load config if present, accomodate common windows naming.
       let truffleConfig;


### PR DESCRIPTION
Added a new config var `copyPackages` to specify which packages to copy from node_modules.

This is really useful for larger projects since copying the whole content of `node_modules` makes `solidity-coverage` consume tons of resources and take a lot of time to complete.