### PR TITLE
Remove only build/contracts

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -114,13 +114,13 @@ class App {
       // Compile the contracts before instrumentation and preserve their ABI's.
       // We will be stripping out access modifiers like view before we recompile
       // post-instrumentation.
-      if (shell.test('-e', `${this.coverageDir}/build`)){
-        shell.rm('-Rf', `${this.coverageDir}/build`)
+      if (shell.test('-e', `${this.coverageDir}/build/contracts`)){
+        shell.rm('-Rf', `${this.coverageDir}/build/contracts`)
       }
 
       this.runCompileCommand();
       this.originalArtifacts = this.loadArtifacts();
-      shell.rm('-Rf', `${this.coverageDir}/build`);
+      shell.rm('-Rf', `${this.coverageDir}/build/contracts`);
 
     } catch (err) {
       const msg = ('There was a problem generating the coverage environment: ');


### PR DESCRIPTION
Apparently, one could use `build/something` to store autogenerated code. Upstream removes that all together. Proposed pull request narrows the scope of a cleaning operation to the truffle-generated files only.