### PR TITLE
Fix parsing bug preventing fn definition in structs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5633,9 +5633,9 @@
       }
     },
     "solidity-parser-sc": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/solidity-parser-sc/-/solidity-parser-sc-0.4.1.tgz",
-      "integrity": "sha512-51kDgZXLCfgOtmxrPPK1Jhgi257emdf8g9xBA7BA5TgFTM8tSEgRzvJGlGTPbI03txLETuSvNpPhy46c+srOyQ==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/solidity-parser-sc/-/solidity-parser-sc-0.4.2.tgz",
+      "integrity": "sha512-KCzHkuCxIlxia4tZxeuWm8MVN5YgcdWNsD/UdO6+bWkZyqBpwJRaHUagvb6IJAT6cNU68M4qWWK2pT9ZiEPiPg==",
       "requires": {
         "mocha": "2.5.3",
         "pegjs": "0.10.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "req-cwd": "^1.0.1",
     "shelljs": "^0.7.4",
     "sol-explore": "^1.6.2",
-    "solidity-parser-sc": "0.4.1",
+    "solidity-parser-sc": "^0.4.2",
     "web3": "^0.18.4"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "req-cwd": "^1.0.1",
     "shelljs": "^0.7.4",
     "sol-explore": "^1.6.2",
-    "solidity-parser-sc": "^0.4.2",
+    "solidity-parser-sc": "0.4.2",
     "web3": "^0.18.4"
   },
   "devDependencies": {

--- a/test/sources/statements/fn-struct.sol
+++ b/test/sources/statements/fn-struct.sol
@@ -1,0 +1,7 @@
+pragma experimental "v0.5.0";
+
+contract Test {
+    struct Fn {
+      function(bytes32) internal constant returns(bool) startConditions;
+    }
+}

--- a/test/statements.js
+++ b/test/statements.js
@@ -17,6 +17,13 @@ describe('generic statements', () => {
   const filePath = path.resolve('./test.sol');
   const pathPrefix = './';
 
+  it('should compile function defined in a struct', () => {
+    const contract = util.getCode('statements/fn-struct.sol');
+    const info = getInstrumentedVersion(contract, filePath);
+    const output = solc.compile(info.contract, 1);
+    util.report(output.errors);
+  })
+
   it('should compile after instrumenting a single statement (first line of function)', () => {
     const contract = util.getCode('statements/single.sol');
     const info = getInstrumentedVersion(contract, filePath);


### PR DESCRIPTION
Found by @stuarth1. PR bumps parser, adds a regression test for this case.

```javascript
struct S {
     function(bytes32) internal constant returns(bool) startConditions;
}
```
 