### PR TITLE
Include lines with comments in line coverage

### DIFF
--- a/lib/instrumenter.js
+++ b/lib/instrumenter.js
@@ -138,9 +138,10 @@ instrumenter.instrumentLine = function instrumentLine(contract, expression) {
   const lastNewLine = contract.instrumented.slice(0, startchar).lastIndexOf('\n');
   const nextNewLine = startchar + contract.instrumented.slice(startchar).indexOf('\n');
   const contractSnipped = contract.instrumented.slice(lastNewLine, nextNewLine);
+  const restOfLine = contract.instrumented.slice(endchar, nextNewLine);
 
   if (contract.instrumented.slice(lastNewLine, startchar).trim().length === 0 &&
-      contract.instrumented.slice(endchar, nextNewLine).replace(';', '').trim().length === 0) {
+      (restOfLine.replace(';', '').trim().length === 0 || restOfLine.replace(';', '').trim().substring(0, 2) === '//')) {
     createOrAppendInjectionPoint(contract, lastNewLine + 1, {
       type: 'callEvent',
     });

--- a/test/comments.js
+++ b/test/comments.js
@@ -4,6 +4,7 @@ const path = require('path');
 const getInstrumentedVersion = require('./../lib/instrumentSolidity.js');
 const util = require('./util/util.js');
 const solc = require('solc');
+const assert = require('assert');
 
 describe('comments', () => {
   const filePath = path.resolve('./test.sol');
@@ -19,6 +20,7 @@ describe('comments', () => {
     const contract = util.getCode('comments/postLineComment.sol');
     const info = getInstrumentedVersion(contract, filePath);
     const output = solc.compile(info.contract, 1);
+    assert.deepEqual([6, 5], info.runnableLines);
     util.report(output.errors);
   });
   it('should cover contracts even if comments are present', () => {


### PR DESCRIPTION
The test for comments after a line just checked that the contracts compiled, not that they were instrumented correctly. It transpires that if a comment was placed on a line, then that line was not included in the line coverage date (though branch coverage etc. was all fine). While branch coverage is the best metric to use, we should make all our metrics correct!

This PR accommodates only lines that have comments with the `//` syntax, which I would expect to be the most common comment style (i.e. I would expect that starting a multiline comment at the end of a line would be unusual; the same for natspec comments). Stripping comments in general requires proper parser support, and I don't think our parser provides us with that information?