### PR TITLE
update FAQ: ethereumjs-testrpc is now ganache-cli

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -33,7 +33,7 @@ node_js:
   - '7'
 install:
   - npm install -g truffle
-  - npm install -g ethereumjs-testrpc
+  - npm install -g ganache-cli
   - npm install
 script:
   - npm test


### PR DESCRIPTION
Updated the Travis CI setup instructions in the FAQ to prevent this warning:

`npm WARN deprecated ethereumjs-testrpc@6.0.3: ethereumjs-testrpc has been renamed to ganache-cli, please use this package from now on.`