### PR TITLE
Fix rpc server launch

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -173,8 +173,8 @@ class App {
   launchTestrpc() {
     return new Promise((resolve, reject) => {
       if (!this.norpc) {
-        const defaultRpcOptions = `--gasLimit ${gasLimitHex} --accounts ${this.accounts} --port ${this.port}`;
-        const options = this.testrpcOptions + ` --gasLimit ${gasLimitHex}` || defaultRpcOptions;
+        const defaultRpcOptions = `--accounts ${this.accounts} --port ${this.port}`;
+        const options = (this.testrpcOptions || defaultRpcOptions) + ` --gasLimit ${gasLimitHex}`;
         const command = './node_modules/ethereumjs-testrpc-sc/build/cli.node.js ';
 
         // Launch


### PR DESCRIPTION
Since `--gasLimit` is added to `testrpcOptions` the left-side of the `||` expression is always true.