### PR TITLE
Update testrpc-sc to 6.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "license": "ISC",
   "dependencies": {
     "death": "^1.1.0",
-    "ethereumjs-testrpc-sc": "6.1.0",
+    "ethereumjs-testrpc-sc": "6.1.2",
     "istanbul": "^0.4.5",
     "keccakjs": "^0.2.1",
     "req-cwd": "^1.0.1",


### PR DESCRIPTION
Updates testrpc-sc to use the latest `ganache-cli`. Tried to take a shortcut in #203 by only updating `ganache-core`, incorrectly.