### PR TITLE
Use require.resolve() to get the path of testrpc-sc

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -176,11 +176,11 @@ class App {
       if (!this.norpc) {
         const defaultRpcOptions = `--accounts ${this.accounts} --port ${this.port}`;
         const options = (this.testrpcOptions || defaultRpcOptions) + ` --gasLimit ${gasLimitHex}`;
-        const command = './node_modules/ethereumjs-testrpc-sc/build/cli.node.js ';
+        const command = require.resolve('ethereumjs-testrpc-sc/build/cli.node.js');
 
         // Launch
         const execOpts = {maxBuffer: 1024 * 1024 * 10};
-        this.testrpcProcess = childprocess.exec(command + options, execOpts, (err, stdout, stderr) => {
+        this.testrpcProcess = childprocess.exec(`${command} ${options}`, execOpts, (err, stdout, stderr) => {
           if (err) {
             if (stdout) this.log(`testRpc stdout:\n${stdout}`);
             if (stderr) this.log(`testRpc stderr:\n${stderr}`);


### PR DESCRIPTION
To be honest, I don't know if this is the best way of doing it...

Getting the path of testrpc dynamically enables solcover to work in mono repos when packages get hoisted to the root directory.