### PR TITLE
Honor excluded files

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -389,6 +389,7 @@ class App {
    */
   postProcessPure(env) {
     shell.ls(`${env}/**/*.sol`).forEach(file => {
+      if (this.skipFiles.includes(file) || this.inSkippedFolder(file)) return;
       const contractPath = this.platformNeutralPath(file);
       const contract = fs.readFileSync(contractPath).toString();
       const contractProcessed = preprocessor.run(contract);


### PR DESCRIPTION
#238

add check to honor the excluded files in `view` and `pure` modifiers processing functionality.

(cherry picked from commit 476dc4d95ce8a69a4d5eda03911efb1391b9005c)

This should make it possible to instrument projects that use Oraclize, as long as the Oraclize contracts are skipped.