### PR TITLE
Revert "Honor excluded files"

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -389,7 +389,6 @@ class App {
    */
   postProcessPure(env) {
     shell.ls(`${env}/**/*.sol`).forEach(file => {
-      if (this.skipFiles.includes(file) || this.inSkippedFolder(file)) return;
       const contractPath = this.platformNeutralPath(file);
       const contract = fs.readFileSync(contractPath).toString();
       const contractProcessed = preprocessor.run(contract);


### PR DESCRIPTION
Reverts sc-forks/solidity-coverage#274

It turns out that this might be problematic, zeppelin's mocks aren't compiling....

`TypeError: Overriding function changes state mutability from "nonpayable" to "view".`

```
/Users/cgewecke/code/sc-forks/zeppelin-solidity/coverageEnv/contracts/mocks/SafeERC20Helper.sol:28:3: TypeError: Overriding function changes state mutability from "nonpayable" to "view".
  function allowance(address, address) public constant returns (uint256) {
  ^ (Relevant source part starts here and spans across multiple lines).
/Users/cgewecke/code/sc-forks/zeppelin-solidity/coverageEnv/contracts/token/ERC20/ERC20.sol:17:3: Overriden function is here:
  function allowance(address owner, address spender) public  returns (uint256);
  ^---------------------------------------------------------------------------^
```