### PR TITLE
Added 'node' to a command

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -214,7 +214,7 @@ class App {
 
         // Launch
         const execOpts = {maxBuffer: 1024 * 1024 * 10};
-        this.testrpcProcess = childprocess.exec(`${command} ${options}`, execOpts, (err, stdout, stderr) => {
+        this.testrpcProcess = childprocess.exec(`node ${command} ${options}`, execOpts, (err, stdout, stderr) => {
           if (err) {
             if (stdout) this.log(`testRpc stdout:\n${stdout}`);
             if (stderr) this.log(`testRpc stderr:\n${stderr}`);


### PR DESCRIPTION
Fixes https://github.com/sc-forks/solidity-coverage/issues/289

Added node in-front of the command being executed by childprocess.exec(). This will make sure that windows will execute the js file rather than opening it in a text editor.