### PR TITLE
Add Istanbul reporter configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,8 @@ module.exports = {
 | skipFiles | *Array* | `['Migrations.sol']` | Array of contracts or folders (with paths expressed relative to the `contracts` directory) that should be skipped when doing instrumentation. `Migrations.sol` is skipped by default, and does not need to be added to this configuration option if it is used. |
 | deepSkip | boolean | false | Use this if instrumentation hangs on large, skipped files (like Oraclize). It's faster. |
 | dir | *String* | `.` | Solidity-coverage copies all the assets in your root directory (except `node_modules`) to a special folder where it instruments the contracts and executes the tests. `dir` allows you to define a relative path from the root directory to those assets. Useful if your contracts & tests are within their own folder as part of a larger project.|
-| buildDirPath | *String* | `/build/contracts` | Build directory path for compiled smart contracts
+| buildDirPath | *String* | `/build/contracts` | Build directory path for compiled smart contracts |
+| reporter | *Array* | `[]` | Coverage reporters for Istanbul 
 
 ### FAQ
 

--- a/lib/app.js
+++ b/lib/app.js
@@ -51,6 +51,7 @@ class App {
     this.testCommand = config.testCommand || null;           // Optional test command
     this.compileCommand = config.compileCommand || null;     // Optional compile command
     this.deepSkip = config.deepSkip || null;                 // Don't post-process skipped files
+    this.reporterOptions = config.reporter || ['html', 'lcov', 'text']; // Coverage reporters for Istanbul
 
     this.setLoggingLevel(config.silent);
   }
@@ -342,9 +343,11 @@ class App {
             fs.writeFileSync('./coverage.json', json);
 
             collector.add(relativeMapping);
-            reporter.add('html');
-            reporter.add('lcov');
-            reporter.add('text');
+
+            if (this.reporterOptions && this.reporterOptions.length) {
+              this.reporterOptions.forEach(report => reporter.add(report));
+            }
+
             reporter.write(collector, true, () => {
               this.log('Istanbul coverage reports generated');
               this.cleanUp();


### PR DESCRIPTION
I would like to propose "reporter" option in order to configure the list of Instanbul reporters, instead of hardcoded values ('html', 'lcov', 'text'). The same option as in .nycrc config file.