### PR TITLE
Add E2E CI tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,27 +1,54 @@
 version: 2.0
 jobs:
- build:
-   docker:
-     - image: circleci/node:8.15.0
-   steps:
-     - checkout
-     - run:
-         name: Delete any old node_modules
-         command: |
-           rm -rf node_modules/
-     - run:
-         name: Install dependencies
-         command: |
-           yarn
-     - run:
-         name: Get submodules
-         command: |
-           git submodule update --init
-     - run:
-         name: Run tests
-         command: |
-           npm run test-cov
-     - run:
-         name: Upload coverage
-         command: |
-           bash <(curl -s https://codecov.io/bash)
+  unit-test:
+    docker:
+      - image: circleci/node:8.15.0
+    steps:
+      - checkout
+      - run:
+          name: Delete any old node_modules
+          command: |
+            rm -rf node_modules/
+      - run:
+          name: Install dependencies
+          command: |
+            yarn
+      - run:
+          name: Get submodules
+          command: |
+            git submodule update --init
+      - run:
+          name: Run tests
+          command: |
+            npm run test-cov
+      - run:
+          name: Upload coverage
+          command: |
+            bash <(curl -s https://codecov.io/bash)
+  e2e-colony:
+    docker:
+      - image: circleci/node:10.12-stretch
+    working_directory: ~/colonyNetwork
+    steps:
+      - checkout
+      - run:
+          name: ColonyNetwork E2E
+          command: |
+            ./scripts/run-colony.sh
+  e2e-zeppelin:
+    docker:
+      - image: circleci/node:10.12-stretch
+    steps:
+      - checkout
+      - run:
+          name: OpenZeppelin E2E
+          command: |
+            ./scripts/run-zeppelin.sh
+
+workflows:
+  version: 2
+  build:
+    jobs:
+      - unit-test
+      - e2e-colony
+      - e2e-zeppelin

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,16 +25,23 @@ jobs:
           name: Upload coverage
           command: |
             bash <(curl -s https://codecov.io/bash)
-  e2e-colony:
-    docker:
-      - image: circleci/node:10.12-stretch
-    working_directory: ~/colonyNetwork
-    steps:
-      - checkout
-      - run:
-          name: ColonyNetwork E2E
-          command: |
-            ./scripts/run-colony.sh
+
+  # This works but takes a while....
+  # e2e-colony:
+  #  docker:
+  #    - image: circleci/node:10.12-stretch
+  #  working_directory: ~/colonyNetwork
+  #  branches:
+  #    only:
+  #      - master
+  #      - next
+  #  steps:
+  #    - checkout
+  #    - run:
+  #        name: ColonyNetwork E2E
+  #        command: |
+  #          ./scripts/run-colony.sh
+
   e2e-zeppelin:
     docker:
       - image: circleci/node:10.12-stretch
@@ -43,12 +50,12 @@ jobs:
       - run:
           name: OpenZeppelin E2E
           command: |
-            ./scripts/run-zeppelin.sh
+            sudo URL=$CIRCLE_REPOSITORY_URL BRANCH=$CIRCLE_BRANCH ./scripts/run-zeppelin.sh
 
 workflows:
   version: 2
   build:
     jobs:
       - unit-test
-      - e2e-colony
       - e2e-zeppelin
+      #- e2e-colony

--- a/scripts/run-colony.sh
+++ b/scripts/run-colony.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+#
+# E2E CI: installs PR candidate on colonyNetwork and runs coverage
+#
+
+set -o errexit
+
+# Get path to PR branch
+PR_PATH=$(echo "$CIRCLE_REPOSITORY_URL#$CIRCLE_BRANCH" | sed 's/git@github.com:/https:\/\/github.com\//')
+echo "Installing $PR_PATH"
+
+# Setup
+sudo npm install -g yarn
+git clone https://github.com/JoinColony/colonyNetwork.git
+cd colonyNetwork || exit
+
+# Swap installed coverage for PR branch version
+sudo yarn
+sudo yarn remove -W solidity-coverage --dev
+sudo yarn add -W "$PR_PATH" --dev
+
+git submodule update --init
+sed -i 's/docker: true,/ /g' truffle.js
+sudo yarn run provision:token:contracts
+sudo yarn run test:contracts:coverage
+
+# Trick to 'allowFailure' on CIRCLE
+set -o errexit

--- a/scripts/run-zeppelin.sh
+++ b/scripts/run-zeppelin.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+#
+# E2E CI: installs PR candidate on openzeppelin-solidity and runs coverage
+#
+
+set -o errexit
+echo "Installing --> $CIRCLE_REPOSITORY_URL#$CIRCLE_BRANCH"
+set -o errexit

--- a/scripts/run-zeppelin.sh
+++ b/scripts/run-zeppelin.sh
@@ -4,5 +4,36 @@
 #
 
 set -o errexit
-echo "Installing --> $CIRCLE_REPOSITORY_URL#$CIRCLE_BRANCH"
+# Get path to PR branch
+PR_PATH=$(echo "$URL#$BRANCH" | sed 's/git@github.com:/https:\/\/github.com\//')
+echo "Installing $PR_PATH"
+
+sudo git clone https://github.com/OpenZeppelin/openzeppelin-solidity.git
+cd openzeppelin-solidity || exit
+
+# EDITS
+# Use testrpc-sc ...
+# sed -i 's/ganache-cli-coverage/testrpc-sc/g' scripts/test.sh
+# sed -i 's/--emitFreeLogs true/ /g' scripts/test.sh
+
+# Do not ping coveralls
+sed -i 's/cat coverage\/lcov.info | npx coveralls/echo "No coveralls"/g' scripts/test.sh
+
+# Doesn't install inside docker (thanks Circle!)
+echo "Uninstalling solidity-docgen"
+sudo npm uninstall --save-dev solidity-docgen
+
+# Swap installed coverage for PR branch version
+echo "Running: npm install"
+sudo npm install
+
+echo "Running npm uninstall solidity-coverage"
+sudo npm uninstall --save-dev solidity-coverage
+
+echo "Running npm install PR_PATH"
+sudo npm install --save-dev "$PR_PATH"
+
+sudo npm run coverage
+
+# Trick to 'allowFailure' on CIRCLE
 set -o errexit


### PR DESCRIPTION
These scripts:
+  clone a large production project (OpenZeppelin, ColonyNetwork)
+  install PR candidate branch on it
+ run coverage.

(This was kind of a deep dive in CircleCI quirks. Everything needs to run with sudo, sudo invoked shell scripts don't share the container's env variables, can't run a docker command inside a script, etc.)

Zeppelin has their own testrpc-sc fork which includes a new feature that emits free logs. This makes it possible to test contracts which gas check w/in solidity. 