### PR TITLE
Upgrade testrpc-sc 6.4.5-sc.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "license": "ISC",
   "dependencies": {
     "death": "^1.1.0",
-    "ethereumjs-testrpc-sc": "6.4.5-sc.2",
+    "ethereumjs-testrpc-sc": "6.4.5-sc.3",
     "istanbul": "^0.4.5",
     "keccakjs": "^0.2.1",
     "req-cwd": "^1.0.1",
@@ -37,7 +37,7 @@
     "ethereumjs-account": "~2.0.4",
     "ethereumjs-tx": "^1.2.2",
     "ethereumjs-util": "^5.0.1",
-    "ethereumjs-vm": "git+https://github.com/sc-forks/ethereumjs-vm-sc.git#3c328147a2c48a379af775930f52c439813a21e2",
+    "ethereumjs-vm": "https://github.com/sc-forks/ethereumjs-vm-sc.git#b77327985b480ace0f11bc899475cadf981ddb65",
     "merkle-patricia-tree": "~2.1.2",
     "mocha": "^4.1.0",
     "request": "^2.88.0",

--- a/test/app.js
+++ b/test/app.js
@@ -341,7 +341,7 @@ describe('app', () => {
     collectGarbage();
   });
 
-  it.skip('contract sends / transfers to instrumented fallback: coverage, cleanup & exit(0)', () => {
+  it('contract sends / transfers to instrumented fallback: coverage, cleanup & exit(0)', () => {
     // Skipped due to https://github.com/sc-forks/solidity-coverage/issues/106
     // Validate ethereumjs-vm hack to remove gas constraints on transfer() and send()
     assert(pathExists('./coverage') === false, 'should start without: coverage');

--- a/yarn.lock
+++ b/yarn.lock
@@ -913,10 +913,10 @@ ethereumjs-common@^1.1.0:
   resolved "https://registry.yarnpkg.com/ethereumjs-common/-/ethereumjs-common-1.3.0.tgz#ca7d152b615d5e1851fcf184d062bf14c62c18e6"
   integrity sha512-/jdFHyHOIS3FiAnunwRZ+oNulFtNNSHyWii3PaNHReOUmBAxij7KMyZLKh0tE16JEsJtXOVz1ceYuq++ILzv+g==
 
-ethereumjs-testrpc-sc@6.4.5-sc.2:
-  version "6.4.5-sc.2"
-  resolved "https://registry.yarnpkg.com/ethereumjs-testrpc-sc/-/ethereumjs-testrpc-sc-6.4.5-sc.2.tgz#c6cd72c7fbaad30ea4c254b98efeb451d185d336"
-  integrity sha512-vqumwbUkH/FCTBkzgL21Pfh9Q5DXVN3o+yoi8u7vsBZSubj0+msg7NBIlU7bkolk2LRpTf4gX6dFab7eY+TNtw==
+ethereumjs-testrpc-sc@6.4.5-sc.3:
+  version "6.4.5-sc.3"
+  resolved "https://registry.yarnpkg.com/ethereumjs-testrpc-sc/-/ethereumjs-testrpc-sc-6.4.5-sc.3.tgz#7c02bfb4c07f32d0ccb30140b61736e5f1bb71c4"
+  integrity sha512-uQD5Tf+C1QgXRx4GkYnlkB6UxLInkbn2gZzwAKLbnDKIzqcv4JiKVUJxnHyYrbXAu0IAxexus7jYnpju2yDHqw==
   dependencies:
     bn.js "4.11.8"
     source-map-support "0.5.9"
@@ -967,9 +967,9 @@ ethereumjs-util@^6.0.0:
     safe-buffer "^5.1.1"
     secp256k1 "^3.0.1"
 
-"ethereumjs-vm@git+https://github.com/sc-forks/ethereumjs-vm-sc.git#3c328147a2c48a379af775930f52c439813a21e2":
+"ethereumjs-vm@https://github.com/sc-forks/ethereumjs-vm-sc.git#b77327985b480ace0f11bc899475cadf981ddb65":
   version "2.6.0"
-  resolved "git+https://github.com/sc-forks/ethereumjs-vm-sc.git#3c328147a2c48a379af775930f52c439813a21e2"
+  resolved "https://github.com/sc-forks/ethereumjs-vm-sc.git#b77327985b480ace0f11bc899475cadf981ddb65"
   dependencies:
     async "^2.1.2"
     async-eventemitter "^0.2.2"


### PR DESCRIPTION
Makes `emitFreeLogs` truly free and fixes #106 (finally). 
Should also resolve the test failures in [aragon-os 541](https://github.com/aragon/aragonOS/pull/541)