### PR TITLE
Fix CI for forks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,17 @@
 version: 2.0
+# Necessary for running in machine mode, which is necessary to execute the
+# Zeppelin and MetaCoin E2E scripts
+step_install_nvm: &step_install_nvm
+  run:
+    name: "Install nvm for machine"
+    command: |
+      set +e
+      export NVM_DIR="/opt/circleci/.nvm"
+      [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+      nvm install v8.15.0
+      nvm alias default v8.15.0
+      echo 'export NVM_DIR="/opt/circleci/.nvm"' >> $BASH_ENV
+      echo "[ -s \"$NVM_DIR/nvm.sh\" ] && . \"$NVM_DIR/nvm.sh\"" >> $BASH_ENV
 jobs:
   unit-test:
     docker:
@@ -56,28 +69,20 @@ jobs:
 
   # AND...this doesn't work either! Thanks to truffle "obtain" and circle permission denied.
   e2e-metacoin:
-    docker:
-      - image: circleci/node:10.12-stretch
+    machine: true
     steps:
       - checkout
-      - run: >
-          sudo npm config set user 0 &&
-          sudo npm config set unsafe-perm true &&
-          sudo rm -rf node_modules &&
-          PR_PATH=$(echo "$CIRCLE_REPOSITORY_URL#$CIRCLE_SHA1" | sudo sed 's/git@github.com:/https:\/\/github.com\//') &&
-          echo "PR_PATH >>>>> $PR_PATH" &&
-          sudo mkdir metacoin &&
-          cd metacoin &&
-          sudo npx truffle unbox metacoin &&
-          sudo rm test/TestMetacoin.sol &&
-          sudo yarn add $PR_PATH --dev &&
-          sudo npx solidity-coverage
+      - <<: *step_install_nvm
+      - run:
+          name: MetaCoin E2E
+          command: |
+            ./scripts/run-metacoin.sh
 workflows:
   version: 2
   build:
     jobs:
-      - unit-test
-      - e2e-zeppelin
+      #- unit-test
+      #- e2e-zeppelin
       - e2e-metacoin
   nightly:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,27 +47,16 @@ jobs:
           command: |
             ./scripts/run-colony.sh
 
-  # It would be nice if all this could be a shell script... :/
   e2e-zeppelin:
-    docker:
-      - image: circleci/node:10.12-stretch
+    machine: true
     steps:
       - checkout
-      - run: >
-          sudo rm -rf node_modules &&
-          PR_PATH=$(echo "$CIRCLE_REPOSITORY_URL#$CIRCLE_SHA1" | sudo sed 's/git@github.com:/https:\/\/github.com\//') &&
-          echo "PR_PATH >>>>> $PR_PATH" &&
-          sudo git clone https://github.com/OpenZeppelin/openzeppelin-solidity.git &&
-          cd openzeppelin-solidity &&
-          sudo sed -i 's/cat coverage\/lcov.info | npx coveralls/echo "No coveralls"/g' scripts/test.sh &&
-          sudo sed -i 's/ganache-cli-coverage/testrpc-sc/g' scripts/test.sh &&
-          sudo sed -i 's/--emitFreeLogs true/ /g' scripts/test.sh &&
-          sudo yarn &&
-          sudo yarn remove solidity-coverage --dev &&
-          sudo yarn add "$PR_PATH" --dev &&
-          sudo npm run coverage
+      - <<: *step_install_nvm
+      - run:
+          name: Zeppelin E2E
+          command: |
+            ./scripts/run-zeppelin.sh
 
-  # AND...this doesn't work either! Thanks to truffle "obtain" and circle permission denied.
   e2e-metacoin:
     machine: true
     steps:
@@ -81,8 +70,8 @@ workflows:
   version: 2
   build:
     jobs:
-      #- unit-test
-      #- e2e-zeppelin
+      - unit-test
+      - e2e-zeppelin
       - e2e-metacoin
   nightly:
     triggers:

--- a/scripts/run-metacoin.sh
+++ b/scripts/run-metacoin.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+#
+# E2E CI: installs PR candidate on Truffle's MetaCoin and runs coverage
+#
+
+# Get rid of any caches
+sudo rm -rf node_modules
+echo "NVM CURRENT >>>>>" && nvm current
+
+# Use PR env variables (for forks) or fallback on local if PR not available
+SED_REGEX="s/git@github.com:/https:\/\/github.com\//"
+
+if [[ -v CIRCLE_PR_REPONAME ]]; then
+  PR_PATH="https://github.com/$CIRCLE_PR_USERNAME/$CIRCLE_PR_REPONAME#$CIRCLE_SHA1"
+else
+  PR_PATH=$(echo "$CIRCLE_REPOSITORY_URL#$CIRCLE_SHA1" | sudo sed "$SED_REGEX")
+fi
+
+echo "PR_PATH >>>>> $PR_PATH"
+
+# Install truffle and metacoin box
+npm install -g truffle
+mkdir metacoin
+cd metacoin
+truffle unbox metacoin --force
+rm test/TestMetacoin.sol
+npm init --yes
+
+# Install and run solidity-coverage @ PR
+npm install --save-dev $PR_PATH
+npx solidity-coverage

--- a/scripts/run-zeppelin.sh
+++ b/scripts/run-zeppelin.sh
@@ -3,40 +3,38 @@
 # E2E CI: installs PR candidate on openzeppelin-solidity and runs coverage
 #
 
-set -o errexit
-# Get path to PR branch
-PR_PATH=$(echo "$URL#$BRANCH" | sed 's/git@github.com:/https:\/\/github.com\//')
-echo "Installing $PR_PATH"
-
-# Circle caches really agressively?
+# Get rid of any caches
 sudo rm -rf node_modules
-sudo git clone https://github.com/OpenZeppelin/openzeppelin-solidity.git
-cd openzeppelin-solidity || exit
-sudo rm -rf node_modules
+echo "NVM CURRENT >>>>>" && nvm current
 
-# EDITS
-# Use testrpc-sc ...
-# sed -i 's/ganache-cli-coverage/testrpc-sc/g' scripts/test.sh
-# sed -i 's/--emitFreeLogs true/ /g' scripts/test.sh
+# Use PR env variables (for forks) or fallback on local if PR not available
+SED_REGEX="s/git@github.com:/https:\/\/github.com\//"
 
-# Do not ping coveralls
+if [[ -v CIRCLE_PR_REPONAME ]]; then
+  PR_PATH="https://github.com/$CIRCLE_PR_USERNAME/$CIRCLE_PR_REPONAME#$CIRCLE_SHA1"
+else
+  PR_PATH=$(echo "$CIRCLE_REPOSITORY_URL#$CIRCLE_SHA1" | sudo sed "$SED_REGEX")
+fi
+
+echo "PR_PATH >>>>> $PR_PATH"
+
+# Install Zeppelin
+git clone https://github.com/OpenZeppelin/openzeppelin-solidity.git
+cd openzeppelin-solidity
+
+# Update Zeppelin's script to use 0.6.x
 sed -i 's/cat coverage\/lcov.info | npx coveralls/echo "No coveralls"/g' scripts/test.sh
-
-# Doesn't install inside docker (thanks Circle!)
-echo "Uninstalling solidity-docgen"
-sudo npm uninstall --save-dev solidity-docgen
+sed -i 's/ganache-cli-coverage/testrpc-sc/g' scripts/test.sh
+sed -i 's/--emitFreeLogs true/ /g' scripts/test.sh
 
 # Swap installed coverage for PR branch version
-echo "Running: npm install"
-sudo npm install
+echo ">>>>> npm install"
+npm install
 
-echo "Running npm uninstall solidity-coverage"
-sudo npm uninstall --save-dev solidity-coverage
+echo ">>>>> npm uninstall --save-dev solidity-coverage"
+npm uninstall --save-dev solidity-coverage
 
-echo "Running npm install PR_PATH"
-sudo npm install --save-dev "$PR_PATH"
+echo ">>>>> npm install --save-dev PR_PATH"
+npm install --save-dev "$PR_PATH"
 
-sudo npm run coverage
-
-# Trick to 'allowFailure' on CIRCLE
-set -o errexit
+npm run coverage


### PR DESCRIPTION
+ Moves all E2E tests into script files and runs Zeppelin / Metacoin on `machine` with nvm (instead of docker)
+ Add logic to pull the correct branch for E2E when running PR from a fork (continuation of #366 - needs to be tested)