### PR TITLE
Adds optional coverage for contracts in node_modules

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -44,6 +44,7 @@ class App {
     this.port = config.port || 8555;             // Port testrpc should listen on
     this.buildDirPath = config.buildDirPath || '/build/contracts' // Build directory path for compiled smart contracts
 
+    this.instrumentImports = config.instrumentImports || false; // Run code coverage on contracts imported from node_modules
     this.copyNodeModules = config.copyNodeModules || false;  // Copy node modules into coverageEnv?
     this.copyPackages = config.copyPackages || [];           // Only copy specific node_modules packages into coverageEnv
     this.testrpcOptions = config.testrpcOptions || null;     // Options for testrpc-sc
@@ -134,6 +135,28 @@ class App {
 
       this.runCompileCommand();
       this.originalArtifacts = this.loadArtifacts();
+
+      // If instrumentImports setting is true, use the contract artifacts to
+      // find the path to all imported contracts. If these paths lead outside
+      // of the /contracts directory (ex. node_modules), copy the contracts
+      // into the coverage environment and save their paths in npmContracts.
+      this.npmContracts = [];
+
+      if (this.instrumentImports) {
+        this.npmContracts = this.originalArtifacts
+          .map(artifact => artifact['sourcePath'])
+          .filter(path => !path.includes('coverageEnv'))
+          .map((file) => {
+            let originalPath = `node_modules/${file}`;
+            let coveragePath = `${this.coverageDir}/${originalPath}`;
+            if (!shell.test('-e', `${this.workingDir}/${coveragePath}`)) {
+              shell.mkdir('-p', path.dirname(coveragePath));
+              shell.cp('-L', originalPath, path.dirname(coveragePath));
+            }
+            return coveragePath;
+          });
+      }
+
       shell.rm('-Rf', `${this.coverageDir}${this.buildDirPath}`);
 
     } catch (err) {
@@ -157,7 +180,7 @@ class App {
     const instrumentedFiles = [];
     let currentFile;
     try {
-      shell.ls(`${this.coverageDir}/contracts/**/*.sol`).forEach(file => {
+      shell.ls(`${this.coverageDir}/contracts/**/*.sol`).concat(this.npmContracts).forEach(file => {
         currentFile = file;
 
         if (!this.skipFiles.includes(file) && !this.inSkippedFolder(file)) {


### PR DESCRIPTION
I made these changes to app.js in order to demonstrate full test coverage of npm imported contracts (such as those from openzeppelin-solidity) in addition to custom contracts, while keeping imported contracts safely in node_modules. In order to activate this feature, you just set the (new) setting "instrumentImports" to true in .solcover.js . 