### PR TITLE
Stop injecting coverage hash fn definition in interfaces

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -5,6 +5,7 @@
  */
 const Registrar = require('./registrar');
 const register = new Registrar();
+const util = require('util');
 
 const parse = {};
 
@@ -51,15 +52,18 @@ parse.ContractDefinition = function(contract, expression) {
 };
 
 parse.ContractOrLibraryStatement = function(contract, expression) {
+
   // We need to define a method to pass coverage hashes into at top of each contract.
   // This lets us get a fresh stack for the hash and avoid stack-too-deep errors.
-  const start = expression.range[0];
-  const end = contract.instrumented.slice(expression.range[0]).indexOf('{') + 1;
-  const loc = start + end;;
+  if (expression.kind !== 'interface'){
+    const start = expression.range[0];
+    const end = contract.instrumented.slice(expression.range[0]).indexOf('{') + 1;
+    const loc = start + end;;
 
-  (contract.injectionPoints[loc])
-    ? contract.injectionPoints[loc].push({ type: 'injectHashMethod'})
-    : contract.injectionPoints[loc] = [{ type: 'injectHashMethod'}];
+    (contract.injectionPoints[loc])
+      ? contract.injectionPoints[loc].push({ type: 'injectHashMethod'})
+      : contract.injectionPoints[loc] = [{ type: 'injectHashMethod'}];
+  }
 
   if (expression.subNodes) {
     expression.subNodes.forEach(construct => {

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -5,7 +5,6 @@
  */
 const Registrar = require('./registrar');
 const register = new Registrar();
-const util = require('util');
 
 const parse = {};
 

--- a/test/sources/solidity/contracts/statements/interface.sol
+++ b/test/sources/solidity/contracts/statements/interface.sol
@@ -1,0 +1,12 @@
+pragma solidity ^0.5.8;
+
+interface IInterface {
+    event Assign(address indexed token, address indexed from, address indexed to, uint256 amount);
+    event Withdraw(address indexed token, address indexed from, address indexed to, uint256 amount);
+
+    // TODO: remove init from the interface, all the initialization should be outside the court
+    function init(address _owner) external;
+
+    function assign(uint _token, address _to, uint256 _amount) external;
+    function withdraw(uint _token, address _to, uint256 _amount) external;
+}

--- a/test/units/statements.js
+++ b/test/units/statements.js
@@ -53,6 +53,11 @@ describe('generic statements', () => {
     util.report(info.solcOutput.errors);
   });
 
+  it('should instrument an interface contract', () => {
+    const info = util.instrumentAndCompile('statements/interface');
+    util.report(info.solcOutput.errors);
+  })
+
   it('should NOT pass tests if the contract has a compilation error', () => {
     const info = util.instrumentAndCompile('app/SimpleError');
     try {


### PR DESCRIPTION
Instrumenting interfaces triggers an error like this:
```
,/contracts/standards/ERC900.sol:6:1: TypeError: Functions in interfaces cannot have an implementation.
function coverage_0xdcb93d1c(bytes32 c__0xdcb93d1c) public pure {}
^----------------------------------------------------------------^
,/contracts/standards/ERC900.sol:6:1: TypeError: Functions in interfaces must be declared external.
function coverage_0xdcb93d1c(bytes32 c__0xdcb93d1c) public pure {}
^----------------------------------------------------------------^
```

Also adds interface test