### PR TITLE
Create separate contract & artifact temp folders at root

### DIFF
--- a/dist/truffle.plugin.js
+++ b/dist/truffle.plugin.js
@@ -50,7 +50,7 @@ async function plugin(truffleConfig){
     coverageConfig = req.silent(coverageConfigPath) || {};
 
     coverageConfig.cwd = truffleConfig.working_directory;
-    coverageConfig.contractsDir = truffleConfig.contracts_directory;
+    coverageConfig.originalContractsDir = truffleConfig.contracts_directory;
 
     app = new App(coverageConfig);
 
@@ -66,8 +66,8 @@ async function plugin(truffleConfig){
     app.instrument();
 
     // Ask truffle to use temp folders
-    truffleConfig.contracts_directory = paths.contracts(app);
-    truffleConfig.build_directory = paths.build(app);
+    truffleConfig.contracts_directory = app.contractsDir;
+    truffleConfig.build_directory = app.artifactsDir;
     truffleConfig.contracts_build_directory = paths.artifacts(truffleConfig, app);
 
     // Additional config
@@ -142,27 +142,11 @@ function loadTruffleLibrary(){
  * @type {Object}
  */
 const paths = {
-  // "contracts_directory":
-  contracts: (app) => {
-     return path.join(
-      app.coverageDir,
-      app.contractsDirName
-    )
-  },
-
-  // "build_directory":
-  build: (app) => {
-    return path.join(
-      app.coverageDir,
-      app.artifactsDirName
-    )
-  },
 
   // "contracts_build_directory":
   artifacts: (truffle, app) => {
     return path.join(
-      app.coverageDir,
-      app.artifactsDirName,
+      app.artifactsDir,
       path.basename(truffle.contracts_build_directory)
     )
   }

--- a/lib/app.js
+++ b/lib/app.js
@@ -23,11 +23,12 @@ class App {
     this.testsErrored = false;
 
     this.cwd = config.cwd;
-    this.tempFolderName = '.coverageEnv';
-    this.contractsDir = config.contractsDir
-    this.coverageDir = path.join(this.cwd, this.tempFolderName);
-    this.contractsDirName = 'contracts';
-    this.artifactsDirName = 'artifacts';
+    this.contractsDirName = '.coverage_contracts';
+    this.artifactsDirName = '.coverage_artifacts';
+    this.contractsDir = path.join(this.cwd, this.contractsDirName);
+    this.artifactsDir = path.join(this.cwd, this.artifactsDirName);
+
+    this.originalContractsDir = config.originalContractsDir
 
     this.client = config.provider;
     this.providerOptions = config.providerOptions || {};
@@ -55,7 +56,7 @@ class App {
       this.registerSkippedItems();
       this.generateEnvelope();
 
-      const target = `${this.coverageDir}/**/*.sol`;
+      const target = `${this.contractsDir}/**/*.sol`;
 
       shell.ls(target).forEach(file => {
         currentFile = file;
@@ -66,9 +67,10 @@ class App {
           // Remember the real path
           const contractPath = this.platformNeutralPath(file);
           const canonicalPath = path.join(
-            this.cwd,
-            contractPath.split(`/${this.tempFolderName}`)[1]
+            this.originalContractsDir,
+            contractPath.split(`/${this.contractsDirName}`)[1]
           );
+
 
           // Instrument contract, save, add to coverage map
           const contract = this.loadContract(contractPath);
@@ -115,7 +117,7 @@ class App {
 
     return new Promise((resolve, reject) => {
       try {
-        this.coverage.generate(this.instrumenter.instrumentationData, this.contractsDir);
+        this.coverage.generate(this.instrumenter.instrumentationData, this.originalContractsDir);
         const relativeMapping = this.makeKeysRelative(this.coverage.data, this.cwd);
         this.saveCoverage(relativeMapping);
 
@@ -147,7 +149,8 @@ class App {
     const self = this;
     this.log('Cleaning up...');
     shell.config.silent = true;
-    shell.rm('-Rf', this.coverageDir);
+    shell.rm('-Rf', this.contractsDir);
+    shell.rm('-Rf', this.artifactsDir);
 
     if (this.provider && this.provider.close){
       this.log('Shutting down ganache-core')
@@ -168,26 +171,31 @@ class App {
   }
 
   saveCoverage(data){
-    fs.writeFileSync('./coverage.json', JSON.stringify(data));
+    const covPath = path.join(this.cwd, "coverage.json");
+    fs.writeFileSync(covPath, JSON.stringify(data));
   }
 
   // ======
   // Launch
   // ======
-  sanityCheckContext(contractsDir){
-    if (!shell.test('-e', this.contractsDir)){
+  sanityCheckContext(){
+    if (!shell.test('-e', this.originalContractsDir)){
       this.cleanUp("Couldn't find a 'contracts' folder to instrument.");
     }
 
-    if (shell.test('-e', path.join(this.cwd, this.coverageDir))){
-      shell.rm('-Rf', this.coverageDir);
+    if (shell.test('-e', path.join(this.cwd, this.contractsDir))){
+      shell.rm('-Rf', this.contractsDir);
+    }
+
+    if (shell.test('-e', path.join(this.cwd, this.artifactsDir))){
+      shell.rm('-Rf', this.artifactsDir);
     }
   }
 
   generateEnvelope(){
-    shell.mkdir(this.coverageDir);
-    shell.mkdir(path.join(this.coverageDir, this.artifactsDirName))
-    shell.cp('-Rf', this.contractsDir, this.coverageDir)
+    shell.mkdir(this.contractsDir);
+    shell.mkdir(this.artifactsDir);
+    shell.cp('-Rf', `${this.originalContractsDir}/*`, this.contractsDir);
   }
 
   // =====
@@ -226,7 +234,7 @@ class App {
    */
   inSkippedFolder(file){
     let shouldSkip;
-    const root = `${this.coverageDir}/${this.contractsDirName}`;
+    const root = `${this.contractsDir}`;
     this.skippedFolders.forEach(folderToSkip => {
       folderToSkip = `${root}/${folderToSkip}`;
       if (file.indexOf(folderToSkip) === 0)
@@ -239,7 +247,7 @@ class App {
    * Parses the skipFiles option (which also accepts folders)
    */
   registerSkippedItems(){
-    const root = `${this.coverageDir}/${this.contractsDirName}`;
+    const root = `${this.contractsDir}`;
     this.skippedFolders = this.skipFiles.filter(item => path.extname(item) !== '.sol')
     this.skipFiles = this.skipFiles.map(contract => `${root}/${contract}`);
     this.skipFiles.push(`${root}/Migrations.sol`);


### PR DESCRIPTION
Fixes bug where importing contracts from outside the contracts directory using a relative path failed under coverage. Changes the temp folder format from
```
.coverageEnv / 
  contracts /
  build /
    contracts /
```
...to 
```
.coverage_contracts /
.coverage_artifacts /
  contracts /
```
