### PR TITLE
Istanbul reporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ a local dependency, please see [this section](https://github.com/sc-forks/solidi
 ### Network Configuration
 
 By default, this tool connects to a coverage-enabled fork of ganache-cli
-called **testrpc-sc** on port 8555. 
+called **testrpc-sc** on port 8555.
 + it's a dependency - there's nothing extra to download.
 + the solidity-coverage command launches it automatically in the background. (See [this section of the FAQ](https://github.com/sc-forks/solidity-coverage/blob/master/docs/faq.md#running-testrpc-sc-on-its-own) if you need to launch it separately yourself)
 
@@ -95,7 +95,8 @@ module.exports = {
 | skipFiles | *Array* | `['Migrations.sol']` | Array of contracts or folders (with paths expressed relative to the `contracts` directory) that should be skipped when doing instrumentation. `Migrations.sol` is skipped by default, and does not need to be added to this configuration option if it is used. |
 | deepSkip | boolean | false | Use this if instrumentation hangs on large, skipped files (like Oraclize). It's faster. |
 | dir | *String* | `.` | Solidity-coverage copies all the assets in your root directory (except `node_modules`) to a special folder where it instruments the contracts and executes the tests. `dir` allows you to define a relative path from the root directory to those assets. Useful if your contracts & tests are within their own folder as part of a larger project.|
-| buildDirPath | *String* | `/build/contracts` | Build directory path for compiled smart contracts
+| buildDirPath | *String* | `/build/contracts` | Build directory path for compiled smart contracts |
+| istanbulReporter | *Array* | ['html', 'lcov', 'text'] | Coverage reporters for Istanbul. Optional reporter replaces the default reporters. |
 
 ### FAQ
 

--- a/README.md
+++ b/README.md
@@ -147,3 +147,4 @@ $ yarn
 + [@pinkiebell](https://github.com/pinkiebell)
 + [@obernardovieira](https://github.com/obernardovieira)
 + [@angus-hamill](https://github.com/angus-hamill)
++ [@kandrianov](https://github.com/kandrianov)

--- a/lib/app.js
+++ b/lib/app.js
@@ -42,6 +42,8 @@ class App {
     this.gasLimit = 0xfffffffffff;
     this.gasLimitString = "0xfffffffffff";
     this.gasPrice = 0x01;
+
+    this.istanbulReporter = config.istanbulReporter || ['html', 'lcov', 'text'];
   }
 
   // --------------------------------------  Methods -----------------------------------------------
@@ -122,9 +124,8 @@ class App {
         this.saveCoverage(relativeMapping);
 
         collector.add(relativeMapping);
-        reporter.add('html');
-        reporter.add('lcov');
-        reporter.add('text');
+
+        this.istanbulReporter.forEach(report => reporter.add(report));
 
         reporter.write(collector, true, () => {
           this.log('Istanbul coverage reports generated');

--- a/test/integration/projects/import-paths/.solcover.js
+++ b/test/integration/projects/import-paths/.solcover.js
@@ -1,3 +1,4 @@
 module.exports = {
   silent: process.env.SILENT ? true : false,
-};
+  istanbulReporter: ['json-summary', 'text']
+}

--- a/test/integration/projects/multiple-migrations/.solcover.js
+++ b/test/integration/projects/multiple-migrations/.solcover.js
@@ -1,3 +1,4 @@
 module.exports = {
   silent: process.env.SILENT ? true : false,
+  istanbulReporter: ['json-summary', 'text']
 };

--- a/test/integration/projects/skipping/.solcover.js
+++ b/test/integration/projects/skipping/.solcover.js
@@ -1,4 +1,5 @@
 module.exports = {
   silent: process.env.SILENT ? true : false,
-  skipFiles: ['skipped-folder']
+  skipFiles: ['skipped-folder'],
+  istanbulReporter: ['json-summary', 'text']
 }

--- a/test/integration/projects/test-files/.solcover.js
+++ b/test/integration/projects/test-files/.solcover.js
@@ -1,3 +1,4 @@
 module.exports = {
   silent: process.env.SILENT ? true : false,
+  istanbulReporter: ['json-summary', 'text']
 }


### PR DESCRIPTION
Ports #308 to the `0.7.0` work, adding an `istanbulReporter` option.

**Example**
```
istanbulReporter: ['json-summary']
```

[List of available reporters](https://istanbul.js.org/docs/advanced/alternative-reporters/)

Adds coverage expectation fixtures to the plugin tests and starts using the json-summary reporter to test percentages.