### PR TITLE
Add --solcoverjs and --help command options

### DIFF
--- a/dist/truffle.plugin.js
+++ b/dist/truffle.plugin.js
@@ -41,19 +41,25 @@ async function plugin(truffleConfig){
   let truffle;
   let testsErrored = false;
   let coverageConfig;
-  let coverageConfigPath;
+  let solcoverjs;
 
   // Load truffle lib, .solcover.js & launch app
   try {
-    truffle = loadTruffleLibrary();
+    (truffleConfig.solcoverjs)
+      ? solcoverjs = path.join(truffleConfig.working_directory, truffleConfig.solcoverjs)
+      : solcoverjs = path.join(truffleConfig.working_directory, '.solcover.js');
 
-    coverageConfigPath = path.join(truffleConfig.working_directory, '.solcover.js');
-    coverageConfig = req.silent(coverageConfigPath) || {};
-
+    coverageConfig = req.silent(solcoverjs) || {};
     coverageConfig.cwd = truffleConfig.working_directory;
     coverageConfig.originalContractsDir = truffleConfig.contracts_directory;
 
     app = new App(coverageConfig);
+
+    if (truffleConfig.help){
+      return app.ui.report('truffle-help')
+    }
+
+    truffle = loadTruffleLibrary();
 
   } catch (err) {
     throw err;

--- a/lib/ui.js
+++ b/lib/ui.js
@@ -23,6 +23,11 @@ class UI {
 
     const kinds = {
 
+      'truffle-help': `Usage: truffle run coverage [options]\n\n` +
+                      `Options:\n` +
+                      `  --file:       path (or glob) to run subset of JS test files\n` +
+                      `  --solcoverjs: relative path to .solcover.js (ex: ./../.solcover.js)\n`,
+
       'truffle-version': `${ct} ${c.bold('truffle')}:      v${args[0]}`,
       'ganache-version': `${ct} ${c.bold('ganache-core')}: ${args[0]}`,
 
@@ -33,7 +38,7 @@ class UI {
                      `\n${c.bold('=====================')}\n`,
 
       'instr-item':    `${ct} ${args[0]}`,
-      'instr-skipped': `${ds} ${c.grey(args[0])}`
+      'instr-skipped': `${ds} ${c.grey(args[0])}`,
     }
 
     this.log(emoji.emojify(kinds[kind]));

--- a/test/util/integration.truffle.js
+++ b/test/util/integration.truffle.js
@@ -97,7 +97,9 @@ function install(
   noMigrations
 ) {
 
-  const configjs = getSolcoverJS(config);
+  let configjs;
+  if(config) configjs = getSolcoverJS(config);
+
   const trufflejs = getTruffleConfigJS(_truffleConfig);
   const migration = deploySingle(contract);
 
@@ -116,7 +118,7 @@ function install(
 
   // Configs
   fs.writeFileSync(`${temp}/${truffleConfigName}`, trufflejs);
-  fs.writeFileSync(configPath, configjs);
+  if(config) fs.writeFileSync(configPath, configjs);
 
   decacheConfigs();
 
@@ -169,6 +171,7 @@ function clean() {
   shell.rm('-Rf', temp);
   shell.rm('-Rf', 'coverage');
   shell.rm('coverage.json');
+  shell.rm('.solcover.js');
 
   shell.config.silent = false;
 };


### PR DESCRIPTION
```
Usage: truffle run coverage [options]

Options: 
  --solcoverjs: relative path to .solcover.js (ex: ./../.solcover.js
  --file: path (or glob) to run subset of JS test files
  --help: help
```

Using `--solcoverjs` in lieu of `--config` because we're subordinate to the plugin APIs and would like to avoid any name conflicts in future...