### PR TITLE
FIX: remove pure view return parameters is an array

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ coverage/
 node_modules/
 .changelog
 .DS_Store
+.idea/

--- a/lib/preprocessor.js
+++ b/lib/preprocessor.js
@@ -25,7 +25,7 @@ function removePureView(contract, node){
   if (node.body){
     fDefEnd = node.body.range[0];
   } else if (node.returnParameters) {
-    fDefEnd = node.returnParameters.range[0];
+    fDefEnd = node.returnParameters[0].range[0];
   } else {
     fDefEnd = node.range[1];
   }


### PR DESCRIPTION
Remove pure view return parameters is an array and should be treated as such otherwise we just get `can not get property '0' of undefined` error since first the array itself does not have property named `range`.