### PR TITLE
Add warnings for deprecated shell commands

### DIFF
--- a/dist/bin.js
+++ b/dist/bin.js
@@ -1,0 +1,8 @@
+/*
+  Logs a warning / informational message when user tries to
+  invoke 'solidity-coverage' as a shell command. This file
+  is listed as the package.json "bin".
+*/
+const AppUI = require('../lib/ui').AppUI;
+
+(new AppUI()).report('command');

--- a/lib/ui.js
+++ b/lib/ui.js
@@ -76,7 +76,14 @@ class AppUI extends UI {
       'cleanup': `${ct} ${c.grey('solidity-coverage cleaning up, shutting down ganache server')}`,
 
       'server':  `${ct} ${c.bold('server: ')}           ${c.grey(args[0])}`,
-    }
+
+      'command': `\n${w}  ${c.red.bold('solidity-coverage >= 0.7.0 is no longer a shell command.')} ${w}\n` +
+                 `${c.bold('=============================================================')}\n\n` +
+                 `Instead, you should use the plugin produced for your development stack\n` +
+                 `(like Truffle, Buidler) or design a custom workflow using the package API\n\n` +
+                 `> See github.com/sc-forks/solidity-coverage for help with configuration.\n\n` +
+                 `${c.green.bold('Thanks! - sc-forks')}\n`,
+    };
 
     this._write(kinds[kind]);
   }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "",
   "main": "index.js",
   "buidler": "dist/buidler.coverage.js",
+  "bin": {
+    "solidity-coverage": "./dist/bin.js"
+  },
   "directories": {
     "test": "test"
   },
@@ -25,7 +28,7 @@
     "chalk": "^2.4.2",
     "death": "^1.1.0",
     "ganache-core-sc": "2.7.0-sc.0",
-    "ghost-testrpc": "^0.0.1",
+    "ghost-testrpc": "^0.0.2",
     "global-modules": "^2.0.0",
     "globby": "^10.0.1",
     "istanbul": "^0.4.5",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "chalk": "^2.4.2",
     "death": "^1.1.0",
     "ganache-core-sc": "2.7.0-sc.0",
+    "ghost-testrpc": "^0.0.1",
     "global-modules": "^2.0.0",
     "globby": "^10.0.1",
     "istanbul": "^0.4.5",

--- a/test/units/truffle/errors.js
+++ b/test/units/truffle/errors.js
@@ -193,4 +193,30 @@ describe('Truffle Plugin: error cases', function() {
 
     verify.coverageNotGenerated(truffleConfig);
   })
+
+  it('user runs "solidity-coverage" as shell command', function(){
+    const pathToCommand = './dist/bin.js';
+    const pkg = require('../../../package.json');
+
+    assert(
+      pkg.bin['solidity-coverage'] === pathToCommand,
+      'bin.js should be pkg.bin'
+    );
+
+    const output = shell.exec(`node ${pathToCommand}`, {silent:true}).stdout;
+
+    assert(
+      output.includes('no longer a shell command'),
+      `should have right info: ${output}`
+    );
+  });
+
+  it('user runs "testrpc-sc" as shell command', function(){
+    const output = shell.exec(`testrpc-sc`, {silent:true}).stdout;
+
+    assert(
+      output.includes('does not use "testrpc-sc"'),
+      `should have right info: ${output}`
+    );
+  });
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -3230,10 +3230,10 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
-ghost-testrpc@^0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/ghost-testrpc/-/ghost-testrpc-0.0.1.tgz#c72cdc96acda344d40e9eeb2cf3c39fd5b931813"
-  integrity sha512-EYaK/iPb8wesxDlJrzOHjoSY9teYaM3A/zXKQKNhOI6Z1rI4V6ZVuTikshyF2x0KV0zgdQtiQlZDXLqYpMHq9g==
+ghost-testrpc@^0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/ghost-testrpc/-/ghost-testrpc-0.0.2.tgz#c4de9557b1d1ae7b2d20bbe474a91378ca90ce92"
+  integrity sha512-i08dAEgJ2g8z5buJIrCTduwPIhih3DP+hOCTyyryikfV8T0bNvHnGXO67i0DD1H4GBDETTclPy9njZbfluQYrQ==
   dependencies:
     chalk "^2.4.2"
     node-emoji "^1.10.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3230,6 +3230,14 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
+ghost-testrpc@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/ghost-testrpc/-/ghost-testrpc-0.0.1.tgz#c72cdc96acda344d40e9eeb2cf3c39fd5b931813"
+  integrity sha512-EYaK/iPb8wesxDlJrzOHjoSY9teYaM3A/zXKQKNhOI6Z1rI4V6ZVuTikshyF2x0KV0zgdQtiQlZDXLqYpMHq9g==
+  dependencies:
+    chalk "^2.4.2"
+    node-emoji "^1.10.0"
+
 glob-parent@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.0.0.tgz#1dc99f0f39b006d3e92c2c284068382f0c20e954"


### PR DESCRIPTION
Ex:

```
$ testrpc-sc
```

![Screen Shot 2019-09-18 at 9 07 46 PM](https://user-images.githubusercontent.com/7332026/65212851-a747f980-da58-11e9-9444-7a051f7dcd24.png)


```
$ solidity-coverage
```
![Screen Shot 2019-09-18 at 9 08 19 PM](https://user-images.githubusercontent.com/7332026/65212867-b4fd7f00-da58-11e9-868e-077a95ea5107.png)
