### PR TITLE
Add 'onCompileComplete' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ $ npm install --save-dev solidity-coverage@beta
 ### Usage notes:
 + Coverage runs tests a little more slowly.
 + Coverage distorts gas consumption. Tests that check exact gas consumption should be skipped.
-+ Coverage launches its own in-process ganache server. 
-+ You can set [ganache options](https://github.com/trufflesuite/ganache-core#options) using the `providerOptions` key in your `.solcover.js` config. 
++ Coverage launches its own in-process ganache server.
++ You can set [ganache options](https://github.com/trufflesuite/ganache-core#options) using the `providerOptions` key in your `.solcover.js` config.
 
 ### Truffle V5
 
@@ -45,6 +45,7 @@ truffle run coverage [options]
 |--------------|------------------------------------|--------------------------------|
 | file     | `--file="test/registry/*.js"`    | Filename or glob describing a subset of JS tests to run. (Globs must be enclosed by quotes.)|
 | solcoverjs | `--solcoverjs ./../.solcover.js` | Relative path from working directory to config. Useful for monorepo packages that share settings. (Path must be "./" prefixed) |
+| network    | `--network development` | Use network settings defined in the Truffle config |
 | version    |                                | Version info |
 | help       |                                | Usage notes  |
 
@@ -71,6 +72,7 @@ module.exports = {
 | mocha | *Object* | `{ }` | [Mocha options](https://mochajs.org/api/mocha) to merge into existing mocha config. `grep` and `invert` are useful for skipping certain tests under coverage using tags in the test descriptions.|
 | onServerReady | *Function* |   | Hook run *after* server is launched, *before* the tests execute. Useful if you need to use the Oraclize bridge or have setup scripts which rely on the server's availability |
 | onTestsComplete | *Function* |  | Hook run *after* the tests complete, *before* Istanbul reports are generated. |
+| onCompileComplete | *Function* |  | Hook run *after* compilation completes, *before* tests are run. Useful if you have secondary compilation steps or need to modify built artifacts. |
 | onIstanbulComplete | *Function* |  | Hook run *after* the Istanbul reports are generated, *before* the ganache server is shut down. Useful if you need to clean resources up. |
 
 

--- a/dist/plugin-assets/truffle.ui.js
+++ b/dist/plugin-assets/truffle.ui.js
@@ -54,8 +54,8 @@ class PluginUI extends UI {
 
 
       'versions':  `${ct} ${c.bold('truffle')}:           v${args[0]}\n` +
-                   `${ct} ${c.bold('ganache-core')}:      ${args[0]}\n` +
-                   `${ct} ${c.bold('solidity-coverage')}: v${args[0]}`,
+                   `${ct} ${c.bold('ganache-core')}:      ${args[1]}\n` +
+                   `${ct} ${c.bold('solidity-coverage')}: v${args[2]}`,
 
       'network': `\n${c.bold('Network Info')}` +
                  `\n${c.bold('============')}\n` +
@@ -78,6 +78,7 @@ class PluginUI extends UI {
    */
   generate(kind, args=[]){
     const c = this.chalk;
+    const x = ":x:";
 
     const kinds = {
 
@@ -90,6 +91,8 @@ class PluginUI extends UI {
       'solcoverjs-fail': `${c.red('Could not load .solcover.js config file. ')}` +
                          `${c.red('This can happen if it has a syntax error or ')}` +
                          `${c.red('the path you specified for it is wrong.')}`,
+
+      'tests-fail': `${x} ${c.bold(args[0])} ${c.red('test(s) failed under coverage.')}`,
 
       'no-network': `${c.red('Network: ')} ${args[0]} ` +
                     `${c.red(' is not defined in your truffle-config networks. ')}`,

--- a/dist/truffle.plugin.js
+++ b/dist/truffle.plugin.js
@@ -93,6 +93,7 @@ async function plugin(config){
 
     // Compile Instrumented Contracts
     await truffle.contracts.compile(config);
+    await api.onCompileComplete(config);
 
     // Run tests
     try {
@@ -100,8 +101,9 @@ async function plugin(config){
     } catch (e) {
       error = e.stack;
     }
-
     await api.onTestsComplete(config);
+
+    // Run Istanbul
     await api.report();
     await api.onIstanbulComplete(config);
 

--- a/dist/truffle.plugin.js
+++ b/dist/truffle.plugin.js
@@ -113,7 +113,7 @@ async function plugin(config){
   await utils.finish(config, api);
 
   if (error !== undefined) throw error;
-  if (failures > 0) throw new Error(`${failures} test(s) failed under coverage.`)
+  if (failures > 0) throw new Error(ui.generate('tests-fail', [failures]));
 }
 
 module.exports = plugin;

--- a/lib/api.js
+++ b/lib/api.js
@@ -35,6 +35,7 @@ class API {
     this.defaultHook = () => {};
     this.onServerReady = config.onServerReady           || this.defaultHook;
     this.onTestsComplete = config.onTestsComplete       || this.defaultHook;
+    this.onCompileComplete = config.onCompileComplete   || this.defaultHook;
     this.onIstanbulComplete = config.onIstanbulComplete || this.defaultHook;
 
     this.server = null;

--- a/test/integration/projects/test-files/.solcover.js
+++ b/test/integration/projects/test-files/.solcover.js
@@ -6,5 +6,6 @@ module.exports = {
   istanbulReporter: ['json-summary', 'text'],
   onServerReady: fn.bind(null, 'running onServerReady'),
   onTestsComplete: fn.bind(null, 'running onTestsComplete'),
+  onCompileComplete: fn.bind(null, 'running onCompileComplete'),
   onIstanbulComplete: fn.bind(null, 'running onIstanbulComplete')
 }

--- a/test/units/truffle/standard.js
+++ b/test/units/truffle/standard.js
@@ -285,6 +285,7 @@ describe('Truffle Plugin: standard use cases', function() {
     assert(
       mock.loggerOutput.val.includes('running onServerReady')     &&
       mock.loggerOutput.val.includes('running onTestsComplete')   &&
+      mock.loggerOutput.val.includes('running onCompileComplete') &&
       mock.loggerOutput.val.includes('running onIstanbulComplete'),
 
       `Should run "on" hooks : ${mock.loggerOutput.val}`


### PR DESCRIPTION
An async hook which runs after compilation, before the tests. It's passed the re-targeted config. It's necessary for projects like JoinColony which have secondary compilation steps and move some files around right before the tests run. (See their npm script step: [provision:token:contracts](https://github.com/JoinColony/colonyNetwork/blob/develop/package.json#L19))

Also fixes a couple bugs in the UI output and adds an entry for `--network` in the CLI options section of the README