### PR TITLE
Add --temp command flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ truffle run coverage [options]
 | file     | `--file="test/registry/*.js"`    | Filename or glob describing a subset of JS tests to run. (Globs must be enclosed by quotes.)|
 | solcoverjs | `--solcoverjs ./../.solcover.js` | Relative path from working directory to config. Useful for monorepo packages that share settings. (Path must be "./" prefixed) |
 | network    | `--network development` | Use network settings defined in the Truffle config |
+| temp       | `--temp build`   | :warning: *Use with caution* :warning:.  Disposable folder to store compilation artifacts in. Useful when your test setup scripts include hard-coded paths to a build directory. |
 | version    |                                | Version info |
 | help       |                                | Usage notes  |
 

--- a/dist/plugin-assets/plugin.utils.js
+++ b/dist/plugin-assets/plugin.utils.js
@@ -85,7 +85,7 @@ function toRelativePath(pathToFile, pathToParent){
 function getTempLocations(config){
   const cwd = config.working_directory;
   const contractsDirName = '.coverage_contracts';
-  const artifactsDirName = '.coverage_artifacts';
+  const artifactsDirName = config.temp || '.coverage_artifacts';
 
   return {
     tempContractsDir: path.join(cwd, contractsDirName),

--- a/test/units/truffle/flags.js
+++ b/test/units/truffle/flags.js
@@ -211,6 +211,20 @@ describe('Truffle Plugin: command line options', function() {
     );
   });
 
+  it('--coverageArtifacts', async function(){
+    truffleConfig.logger = mock.testLogger;
+
+    truffleConfig.temp = 'special_location';
+
+    mock.install('Simple', 'simple.js', solcoverConfig);
+    await plugin(truffleConfig);
+
+    assert(
+      mock.loggerOutput.val.includes("/special_location/contracts"),
+      `Should write artifacts to "special_location": ${mock.loggerOutput.val}`
+    );
+  });
+
   it('--network (network_id mismatch in configs)', async function(){
     truffleConfig.logger = mock.testLogger;
 


### PR DESCRIPTION
Specifies the name of the folder to write compilation artifacts to. A use case is colonyNetwork where there are complex scripts to set up the tests which consume various pieces of the Truffle artifact. All this logic assumes they exist under`build` (rather than `.coverage_artifacts`).

This folder gets created/deleted and needs to be disposable. The user cannot store meaningful deployment data in it. 