### PR TITLE
Add simple E2E for Buidler

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,6 +73,15 @@ jobs:
           name: MetaCoin E2E
           command: |
             ./scripts/run-metacoin.sh
+  e2e-buidler:
+    machine: true
+    steps:
+      - checkout
+      - <<: *step_install_nvm
+      - run:
+          name: Buidler E2E
+          command: |
+            ./scripts/run-buidler.sh
 workflows:
   version: 2
   build:
@@ -80,6 +89,7 @@ workflows:
       - unit-test
       - e2e-zeppelin
       - e2e-metacoin
+      - e2e-buidler
   # TODO: re-enable.
   # At the moment we're using forks so this is pointless
   #nightly:

--- a/package.json
+++ b/package.json
@@ -2,8 +2,7 @@
   "name": "solidity-coverage",
   "version": "0.7.0-beta.2",
   "description": "",
-  "main": "index.js",
-  "buidler": "dist/buidler.coverage.js",
+  "main": "dist/buidler.plugin.js",
   "bin": {
     "solidity-coverage": "./dist/bin.js"
   },

--- a/scripts/run-buidler.sh
+++ b/scripts/run-buidler.sh
@@ -29,3 +29,9 @@ npm install
 # Install and run solidity-coverage @ PR
 npm install --save-dev $PR_PATH
 npx buidler coverage
+
+# Test that coverage/ was generated
+if [ ! -d "coverage" ]; then
+  echo "ERROR: no coverage folder was created."
+  exit 1
+fi

--- a/scripts/run-buidler.sh
+++ b/scripts/run-buidler.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+#
+# E2E CI: installs PR candidate on sc-forks/buidler-e2e (a simple example,
+# similar to Metacoin) and runs coverage
+#
+
+set -o errexit
+
+# Get rid of any caches
+sudo rm -rf node_modules
+echo "NVM CURRENT >>>>>" && nvm current
+
+# Use PR env variables (for forks) or fallback on local if PR not available
+SED_REGEX="s/git@github.com:/https:\/\/github.com\//"
+
+if [[ -v CIRCLE_PR_REPONAME ]]; then
+  PR_PATH="https://github.com/$CIRCLE_PR_USERNAME/$CIRCLE_PR_REPONAME#$CIRCLE_SHA1"
+else
+  PR_PATH=$(echo "$CIRCLE_REPOSITORY_URL#$CIRCLE_SHA1" | sudo sed "$SED_REGEX")
+fi
+
+echo "PR_PATH >>>>> $PR_PATH"
+
+# Install buidler e2e test
+git clone https://github.com/sc-forks/buidler-e2e.git
+cd buidler-e2e
+npm install
+
+# Install and run solidity-coverage @ PR
+npm install --save-dev $PR_PATH
+npx buidler coverage

--- a/scripts/run-metacoin.sh
+++ b/scripts/run-metacoin.sh
@@ -39,3 +39,10 @@ cat truffle-config.js
 npm init --yes
 yarn add $PR_PATH --dev
 npx truffle run coverage
+
+# Test that coverage/ was generated
+if [ ! -d "coverage" ]; then
+  echo "ERROR: no coverage folder was created."
+  exit 1
+fi
+

--- a/truffle-plugin.json
+++ b/truffle-plugin.json
@@ -1,5 +1,5 @@
 {
   "commands": {
-    "coverage": "dist/truffle.plugin.js"
+    "coverage": "truffle.plugin.js"
   }
 }


### PR DESCRIPTION
+ clones [sc-forks/buidler-e2e][1] and installs/runs solidity-coverage at a candidate branch.


[1]: https://github.com/sc-forks/buidler-e2e