### PR TITLE
Moloch E2E

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,7 @@
 version: 2.0
-# Necessary for running in machine mode, which is necessary to execute the
-# Zeppelin and MetaCoin E2E scripts
+
+# Necessary for running in machine mode,
+# which is necessary to execute the E2E scripts
 step_install_nvm: &step_install_nvm
   run:
     name: "Install nvm for machine"
@@ -12,6 +13,7 @@ step_install_nvm: &step_install_nvm
       nvm alias default v8.15.0
       echo 'export NVM_DIR="/opt/circleci/.nvm"' >> $BASH_ENV
       echo "[ -s \"$NVM_DIR/nvm.sh\" ] && . \"$NVM_DIR/nvm.sh\"" >> $BASH_ENV
+
 jobs:
   unit-test:
     machine: true
@@ -82,6 +84,15 @@ jobs:
           name: Buidler E2E
           command: |
             ./scripts/run-buidler.sh
+  e2e-moloch:
+    machine: true
+    steps:
+      - checkout
+      - <<: *step_install_nvm
+      - run:
+          name: Moloch E2E
+          command: |
+            ./scripts/run-moloch.sh
 workflows:
   version: 2
   build:
@@ -90,16 +101,4 @@ workflows:
       - e2e-zeppelin
       - e2e-metacoin
       - e2e-buidler
-  # TODO: re-enable.
-  # At the moment we're using forks so this is pointless
-  #nightly:
-  #  triggers:
-  #    - schedule:
-  #        cron: "0 1 * * *" # 1am UTC
-  #        filters:
-  #          branches:
-  #            only:
-  #              - master
-  #  jobs:
-      #- e2e-zeppelin
-      #- e2e-colony
+      - e2e-moloch

--- a/scripts/run-moloch.sh
+++ b/scripts/run-moloch.sh
@@ -22,7 +22,7 @@ fi
 echo "PR_PATH >>>>> $PR_PATH"
 
 # Install buidler e2e test
-git clone https://github.com/sc-forks/moloch.git#buidler-upgrade-coverage
+git clone https://github.com/sc-forks/moloch.git
 cd moloch
 npm install
 npm uninstall --save-dev solidity-coverage

--- a/scripts/run-moloch.sh
+++ b/scripts/run-moloch.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+#
+# E2E CI: installs PR candidate on sc-forks/buidler-e2e (a simple example,
+# similar to Metacoin) and runs coverage
+#
+
+set -o errexit
+
+# Get rid of any caches
+sudo rm -rf node_modules
+echo "NVM CURRENT >>>>>" && nvm current
+
+# Use PR env variables (for forks) or fallback on local if PR not available
+SED_REGEX="s/git@github.com:/https:\/\/github.com\//"
+
+if [[ -v CIRCLE_PR_REPONAME ]]; then
+  PR_PATH="https://github.com/$CIRCLE_PR_USERNAME/$CIRCLE_PR_REPONAME#$CIRCLE_SHA1"
+else
+  PR_PATH=$(echo "$CIRCLE_REPOSITORY_URL#$CIRCLE_SHA1" | sudo sed "$SED_REGEX")
+fi
+
+echo "PR_PATH >>>>> $PR_PATH"
+
+# Install buidler e2e test
+git clone https://github.com/sc-forks/moloch.git#buidler-upgrade-coverage
+cd moloch
+npm install
+npm uninstall --save-dev solidity-coverage
+
+# Install and run solidity-coverage @ PR
+npm install --save-dev $PR_PATH
+npm run coverage
+
+# Test that coverage/ was generated
+if [ ! -d "coverage" ]; then
+  echo "ERROR: no coverage folder was created."
+  exit 1
+fi


### PR DESCRIPTION
Adds MolochVentures/moloch as an E2E (Buidler) target, using the [sc-forks/moloch fork][1] (which is a fork of alcuadrado/moloch. Root repo is not pulling in upgrade PRs & development is breaking the tests on master. 

[1]: https://github.com/sc-forks/moloch
 