### PR TITLE
Stop camel-casing testfiles flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ npx buidler coverage [command-options]
 | Option <img width=200/> | Example <img width=750/>| Description <img width=1000/> |
 |--------------|------------------------------------|--------------------------------|
 | file | `--file="test/registry/*.js"`    | (Truffle) Filename or glob describing a subset of JS tests to run. (Globs must be enclosed by quotes.)|
-| testFiles  | `--testFiles test/file.js` | (Buidler) JS test file(s) to run.|
+| testfiles  | `--testfiles test/file.js` | (Buidler) JS test file(s) to run.|
 | solcoverjs | `--solcoverjs ./../.solcover.js` | Relative path from working directory to config. Useful for monorepo packages that share settings. (Path must be "./" prefixed) |
 | network    | `--network development` | Use network settings defined in the Truffle or Buidler config |
 | temp[<sup>*</sup>][14]       | `--temp build`   | :warning: **Caution** :warning:  Path to a *disposable* folder to store compilation artifacts in. Useful when your test setup scripts include hard-coded paths to a build directory. [More...][14] |

--- a/dist/buidler.plugin.js
+++ b/dist/buidler.plugin.js
@@ -26,7 +26,7 @@ function plugin() {
 
   task("coverage", "Generates a code coverage report for tests")
 
-    .addOptionalParam("testFiles",  ui.flags.file,       null, types.string)
+    .addOptionalParam("testfiles",  ui.flags.file,       null, types.string)
     .addOptionalParam("solcoverjs", ui.flags.solcoverjs, null, types.string)
     .addOptionalParam('temp',       ui.flags.temp,       null, types.string)
 
@@ -112,10 +112,10 @@ function plugin() {
         // ======
         // Tests
         // ======
-        const testFiles = args.testFiles ? [args.testFiles] : [];
+        const testfiles = args.testfiles ? [args.testfiles] : [];
 
         try {
-          await env.run(TASK_TEST, {testFiles: testFiles})
+          await env.run(TASK_TEST, {testFiles: testfiles})
         } catch (e) {
           error = e;
         }

--- a/test/units/buidler/flags.js
+++ b/test/units/buidler/flags.js
@@ -85,9 +85,9 @@ describe('Buidler Plugin: command line options', function() {
     verify.lineCoverage(expected);
   });
 
-  it('--testFiles test/<fileName>', async function() {
+  it.only('--testfiles test/<fileName>', async function() {
     const taskArgs = {
-      testFiles: path.join(
+      testfiles: path.join(
         buidlerConfig.paths.root,
         'test/specific_a.js'
       )


### PR DESCRIPTION
Buidler requires command line params to be lowercase
```
Error BDLR310: Invalid param --testFiles. Command line params must be lowercase.
```
