### PR TITLE
Export API

### DIFF
--- a/api.js
+++ b/api.js
@@ -1,0 +1,4 @@
+// For require('solidity-coverage/api');
+const api = require('./lib/api');
+
+module.exports = api;

--- a/lib/api.js
+++ b/lib/api.js
@@ -3,7 +3,6 @@ const pify = require('pify');
 const fs = require('fs');
 const path = require('path');
 const istanbul = require('istanbul');
-const util = require('util');
 const assert = require('assert');
 const detect = require('detect-port');
 const _ = require('lodash/lang');
@@ -13,6 +12,8 @@ const Instrumenter = require('./instrumenter');
 const Coverage = require('./coverage');
 const DataCollector = require('./collector');
 const AppUI = require('./ui').AppUI;
+const utils = require('./../plugins/resources/plugin.utils');
+
 
 /**
  * Coverage Runner
@@ -60,6 +61,7 @@ class API {
 
     this.setLoggingLevel(config.silent);
     this.ui = new AppUI(this.log);
+    this.utils = utils;
   }
 
   /**
@@ -175,9 +177,11 @@ class API {
   /**
    * Generate coverage / write coverage report / run istanbul
    */
-  async report() {
+  async report(_folder) {
+    const folder = _folder || this.istanbulFolder;
+
     const collector = new istanbul.Collector();
-    const reporter = new istanbul.Reporter(false, this.istanbulFolder);
+    const reporter = new istanbul.Reporter(false, folder);
 
     return new Promise((resolve, reject) => {
       try {

--- a/plugins/resources/plugin.utils.js
+++ b/plugins/resources/plugin.utils.js
@@ -267,7 +267,6 @@ module.exports = {
   loadSolcoverJS: loadSolcoverJS,
   reportSkipped: reportSkipped,
   save: save,
-  checkContext: checkContext,
   toRelativePath: toRelativePath,
   setupTempFolders: setupTempFolders
 }

--- a/test/units/api.js
+++ b/test/units/api.js
@@ -1,6 +1,6 @@
 const assert = require('assert');
 const util = require('./../util/util.js');
-const API = require('./../../lib/api.js');
+const API = require('./../../api.js');
 const detect = require('detect-port');
 const Ganache = require('ganache-cli');
 
@@ -85,4 +85,16 @@ describe('api', () => {
 
     assert(freePort === port);
   })
+
+  it('api.utils', async function(){
+    const api = new API(opts);
+    assert(api.utils.assembleFiles !== undefined)
+    assert(api.utils.checkContext !== undefined)
+    assert(api.utils.finish !== undefined)
+    assert(api.utils.getTempLocations !== undefined)
+    assert(api.utils.setupTempFolders !== undefined)
+    assert(api.utils.loadSource !== undefined)
+    assert(api.utils.loadSolcoverJS !== undefined)
+    assert(api.utils.save !== undefined)
+  });
 })


### PR DESCRIPTION
This...
```javascript
const API = require('solidity-coverage/api');
const api = new API();

const config = {
  workingDir: process.cwd(),
  contractsDir: path.join(process.cwd(), 'contracts')
  artifactsDir: path.join(process.cwd(), 'artifacts')
} 

const {
  targets,
  skipped, 
} = api.utils.assembleFiles(config)

const instrumented = api.instrument(targets)
```

Also makes `api.report`'s output folder path configurable as an fn argument.
