### PR TITLE
Disable eth-gas-reporter when present in truffle config

### DIFF
--- a/plugins/resources/truffle.utils.js
+++ b/plugins/resources/truffle.utils.js
@@ -194,6 +194,12 @@ function normalizeConfig(config){
   config.testDir = config.test_directory;
   config.artifactsDir = config.build_directory;
 
+  // eth-gas-reporter freezes the in-process client because it uses sync calls
+  if (typeof config.mocha === "object" && config.mocha.reporter === 'eth-gas-reporter'){
+    config.mocha.reporter = 'spec';
+    delete config.mocha.reporterOptions;
+  }
+
   return config;
 }
 

--- a/test/units/truffle/standard.js
+++ b/test/units/truffle/standard.js
@@ -215,6 +215,14 @@ describe('Truffle Plugin: standard use cases', function() {
     );
   });
 
+  // This test errors if the reporter is not re-designated as 'spec' correctly
+  it('gracefully disables eth-gas-reporter', async function(){
+    truffleConfig.mocha = { reporter: 'eth-gas-reporter' };
+
+    mock.install('Simple', 'simple.js', solcoverConfig);
+    await plugin(truffleConfig);
+  });
+
   // This test tightly coupled to the ganache version in production deps
   // "test-files" project solcoverjs includes `client: require('ganache-cli')`
   it('config: client', async function(){


### PR DESCRIPTION
#423

It hangs & its gas data is meaningless here.