### PR TITLE
Allow Truffle V4 style solc config

### DIFF
--- a/plugins/resources/truffle.utils.js
+++ b/plugins/resources/truffle.utils.js
@@ -200,6 +200,12 @@ function normalizeConfig(config){
     delete config.mocha.reporterOptions;
   }
 
+  // Truffle V4 style solc settings are honored over V5 settings. Apparently it's common
+  // for both to be present in the same config (as an error).
+  if (typeof config.solc === "object" ){
+    config.solc.optimizer = { enabled: false };
+  }
+
   return config;
 }
 

--- a/test/units/truffle/standard.js
+++ b/test/units/truffle/standard.js
@@ -216,11 +216,34 @@ describe('Truffle Plugin: standard use cases', function() {
   });
 
   // This test errors if the reporter is not re-designated as 'spec' correctly
-  it('gracefully disables eth-gas-reporter', async function(){
+  it('disables eth-gas-reporter', async function(){
     truffleConfig.mocha = { reporter: 'eth-gas-reporter' };
 
     mock.install('Simple', 'simple.js', solcoverConfig);
     await plugin(truffleConfig);
+  });
+
+  it('disables optimization when truffle-config uses V4 format', async function(){
+    solcoverConfig = {
+      silent: process.env.SILENT ? true : false,
+      istanbulReporter: ['json-summary', 'text']
+    };
+
+    truffleConfig.solc = {
+      optimizer: { enabled: true, runs: 200 }
+    };
+
+    mock.install('Simple', 'simple.js', solcoverConfig);
+    await plugin(truffleConfig);
+
+    const expected = [
+      {
+        file: mock.pathToContract(truffleConfig, 'Simple.sol'),
+        pct: 100
+      }
+    ];
+
+    verify.lineCoverage(expected);
   });
 
   // This test tightly coupled to the ganache version in production deps


### PR DESCRIPTION
#434 

Handles this case, coercing V4 format optimization to false:

```javascript
module.exports = {
  plugins: ["solidity-coverage"],

  compilers: {
    solc: {
      version: "0.5.11"
    }
  },
  solc: {
    optimizer: {
      enabled: true,
      runs: 200
    }
  }
};
```