### PR TITLE
Add missing hash bang to .bin warning

### DIFF
--- a/plugins/bin.js
+++ b/plugins/bin.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 /*
   Logs a warning / informational message when user tries to
   invoke 'solidity-coverage' as a shell command. This file

--- a/test/units/truffle/errors.js
+++ b/test/units/truffle/errors.js
@@ -216,7 +216,7 @@ describe('Truffle Plugin: error cases', function() {
       'bin.js should be pkg.bin'
     );
 
-    const output = shell.exec(`${pathToCommand}`, {silent:true}).stdout;
+    const output = shell.exec(`node ${pathToCommand}`, {silent:true}).stdout;
 
     assert(
       output.includes('no longer a shell command'),

--- a/test/units/truffle/errors.js
+++ b/test/units/truffle/errors.js
@@ -216,7 +216,7 @@ describe('Truffle Plugin: error cases', function() {
       'bin.js should be pkg.bin'
     );
 
-    const output = shell.exec(`node ${pathToCommand}`, {silent:true}).stdout;
+    const output = shell.exec(`${pathToCommand}`, {silent:true}).stdout;
 
     assert(
       output.includes('no longer a shell command'),


### PR DESCRIPTION
The warning added in #405 for `$ solidity-coverage` doesn't work in practice because it's missing a node hash bang. 

See [gnosis/dex-contract comment](https://github.com/gnosis/dex-contracts/pull/436#issuecomment-570512513). 

Should look like:

![Screen Shot 2020-01-03 at 12 07 10 PM](https://user-images.githubusercontent.com/7332026/71746400-a7aaab80-2e21-11ea-908e-2e28a96c848a.png)
