### PR TITLE
Get test files after compileComplete hook runs (Truffle)

### DIFF
--- a/plugins/truffle.plugin.js
+++ b/plugins/truffle.plugin.js
@@ -95,13 +95,13 @@ async function plugin(config){
     );
 
     config.all = true;
-    config.test_files = await truffleUtils.getTestFilePaths(config);
     config.compilers.solc.settings.optimizer.enabled = false;
 
     // Compile Instrumented Contracts
     await truffle.contracts.compile(config);
     await api.onCompileComplete(config);
 
+    config.test_files = await truffleUtils.getTestFilePaths(config);
     // Run tests
     try {
       failures = await truffle.test.run(config)


### PR DESCRIPTION
Should fix a problem discovered in [dai-backstop-syndicate 45][1] where test files written in TS are  transpiled to the build folder, 

PR fetches test files immediately before `truffle.test` is run so there's less likelyhood they'll be accidentally overwritten by `truffle.compile`

[1]: https://github.com/backstop-syndicate/dai-backstop-syndicate/pull/45