### PR TITLE
Allowing providerOptions gasLimit and allowUnlimitedContractSize to override defaults

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -145,8 +145,15 @@ class API {
 
     this.collector = new DataCollector(this.instrumenter.instrumentationData);
 
-    this.providerOptions.gasLimit = this.gasLimitString;
-    this.providerOptions.allowUnlimitedContractSize = true;
+    this.providerOptions.gasLimit =
+      'gasLimit' in this.providerOptions
+        ? this.providerOptions.gasLimit
+        : this.gasLimitString;
+
+    this.providerOptions.allowUnlimitedContractSize =
+      'allowUnlimitedContractSize' in this.providerOptions
+        ? this.providerOptions.allowUnlimitedContractSize
+        : this.allowUnlimitedContractSize;
 
     // Attach to vm step of supplied client
     try {

--- a/lib/api.js
+++ b/lib/api.js
@@ -153,7 +153,7 @@ class API {
     this.providerOptions.allowUnlimitedContractSize =
       'allowUnlimitedContractSize' in this.providerOptions
         ? this.providerOptions.allowUnlimitedContractSize
-        : this.allowUnlimitedContractSize;
+        : true;
 
     // Attach to vm step of supplied client
     try {


### PR DESCRIPTION
By allowing `providerOptions.gasLimit` be included in `.solcover.js`, it allows us at Synthetix to avoid these `Exceeds block gas limit` errors, see : https://travis-ci.org/github/Synthetixio/synthetix/jobs/672297483#L2100-L2148. 

> Note: I added support for `allowUnlimitedContractSize` as well cause I was in there and it seemed prudent