### PR TITLE
docs: fix installation script in buidler readme

### DIFF
--- a/BUIDLER_README.md
+++ b/BUIDLER_README.md
@@ -19,7 +19,7 @@ Solidity code coverage plugin for [buidler](http://getbuidler.com).
 ## Installation
 
 ```bash
-$ npm install --save-dev solidity-coverage@beta
+$ npm install --save-dev solidity-coverage
 ```
 
 And add the following to your `buidler.config.js`:


### PR DESCRIPTION
I was using the solidity-coverage buidler plugin and encountered the issue described in #489.

This PR fixes the installation script in the README by removing "@beta" from the package name, hence installing the latest available version (0.7.5 at the time of writing this).