### PR TITLE
Parse TryStatements and catchClauses

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -171,6 +171,17 @@ parse.ReturnStatement = function(contract, expression) {
   parse[subExpression.argument.type](contract, expression.argument);
 };*/
 
+parse.TryStatement = function(contract, expression) {
+  register.statement(contract, expression);
+  parse[expression.body.type] &&
+  parse[expression.body.type](contract, expression.body);
+
+  for (let x = 0; x < expression.catchClauses.length; x++) {
+    parse[expression.catchClauses[x].body.type] &&
+    parse[expression.catchClauses[x].body.type](contract, expression.catchClauses[x].body);
+  }
+};
+
 parse.UsingStatement = function (contract, expression) {
   parse[expression.for.type] &&
   parse[expression.for.type](contract, expression.for);

--- a/test/integration/projects/solc-6/contracts/ContractA.sol
+++ b/test/integration/projects/solc-6/contracts/ContractA.sol
@@ -43,7 +43,7 @@ contract ContractA is ContractB {
         errorCount++;
         return (0, false);
     } catch (bytes memory) {
-        errorCount++;
+        errorCount = errorCount + 1;
         return (0, false);
     }
   }

--- a/test/units/buidler/standard.js
+++ b/test/units/buidler/standard.js
@@ -284,7 +284,7 @@ describe('Buidler Plugin: standard use cases', function() {
     const expected = [
       {
         file: mock.pathToContract(buidlerConfig, 'ContractA.sol'),
-        pct: 87.5
+        pct: 61.54
       },
       {
         file: mock.pathToContract(buidlerConfig, 'ContractB.sol'),


### PR DESCRIPTION
#520 

Add parsing for `TryStatement` body and its `catchClause` bodies. 

![Screen Shot 2020-06-17 at 8 17 47 AM](https://user-images.githubusercontent.com/7332026/84919562-eef6c280-b076-11ea-9494-0d91cbda9f8b.png)


In #520 it's suggested that this structure be reported as a branch. Haven't done that here - am not sure if that's typical for other languages. However, it could be meaningful in cases where the catch block is left intentionally empty and your intent is to swallow the error. Atm an error path without statements isn't visually flagged.

 
