### PR TITLE
Expand `testfiles` arg globs

### DIFF
--- a/plugins/buidler.plugin.js
+++ b/plugins/buidler.plugin.js
@@ -119,7 +119,9 @@ function plugin() {
         // ======
         // Tests
         // ======
-        const testfiles = args.testfiles ? [args.testfiles] : [];
+        const testfiles = args.testfiles
+          ? buidlerUtils.getTestFilePaths(args.testfiles)
+          : [];
 
         try {
           await env.run(TASK_TEST, {testFiles: testfiles})

--- a/plugins/resources/buidler.utils.js
+++ b/plugins/resources/buidler.utils.js
@@ -11,6 +11,19 @@ const { createProvider } = require("@nomiclabs/buidler/internal/core/providers/c
 // =============================
 
 /**
+ * Returns a list of test files to pass to mocha.
+ * @param  {String}   files   file or glob
+ * @return {String[]}         list of files to pass to mocha
+ */
+function getTestFilePaths(files){
+  const target = globby.sync([files])
+
+  // Buidler supports js & ts
+  const testregex = /.*\.(js|ts)$/;
+  return target.filter(f => f.match(testregex) != null);
+}
+
+/**
  * Normalizes buidler paths / logging for use by the plugin utilities and
  * attaches them to the config
  * @param  {BuidlerConfig} config
@@ -104,6 +117,7 @@ module.exports = {
   normalizeConfig: normalizeConfig,
   finish: finish,
   tempCacheDir: tempCacheDir,
-  setupNetwork: setupNetwork
+  setupNetwork: setupNetwork,
+  getTestFilePaths: getTestFilePaths
 }
 

--- a/test/units/buidler/flags.js
+++ b/test/units/buidler/flags.js
@@ -116,6 +116,37 @@ describe('Buidler Plugin: command line options', function() {
     verify.lineCoverage(expected);
   });
 
+  it('--file test/<glob*>', async function() {
+    const taskArgs = {
+      testfiles: path.join(
+        buidlerConfig.paths.root,
+        'test/**/globby*'
+      )
+    };
+
+    mock.installFullProject('test-files');
+    mock.buidlerSetupEnv(this);
+
+    await this.env.run("coverage", taskArgs);
+
+    const expected = [
+      {
+        file: mock.pathToContract(buidlerConfig, 'ContractA.sol'),
+        pct: 0,
+      },
+      {
+        file: mock.pathToContract(buidlerConfig, 'ContractB.sol'),
+        pct: 100,
+      },
+      {
+        file: mock.pathToContract(buidlerConfig, 'ContractC.sol'),
+        pct: 100,
+      },
+    ];
+
+    verify.lineCoverage(expected);
+  });
+
   it('--config ../.solcover.js', async function() {
     // Write solcoverjs to parent dir of sc_temp (where the test project is installed)
     fs.writeFileSync(


### PR DESCRIPTION
[buidler 665][1]

Passes arg to `globby` 

These may auto-expand if `testfiles` is registered using `.addOptionalPositionalParam` (as suggested) but was not able to get this to work in tests. Don't see any glob expansion logic in the buidler `test` task - could be elsewhere though. 


[1]: https://github.com/nomiclabs/buidler/issues/665