### PR TITLE
Bump parser to 0.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@solidity-parser/parser": "^0.6.0",
+    "@solidity-parser/parser": "^0.7.0",
     "@truffle/provider": "^0.1.17",
     "chalk": "^2.4.2",
     "death": "^1.1.0",


### PR DESCRIPTION
This will fix all issues with solidity 0.7.0 crashing on start.