### PR TITLE
Use commit url for @openzeppelin/test-environment example

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,5 +211,5 @@ $ yarn
 [32]: https://github.com/sc-forks/buidler-e2e/tree/coverage
 [33]: https://github.com/sc-forks/moloch
 [34]: https://github.com/sc-forks/solidity-coverage/blob/master/docs/advanced.md#reducing-the-instrumentation-footprint
-[35]: https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/scripts/coverage.js
+[35]: https://github.com/OpenZeppelin/openzeppelin-contracts/blob/e5fbbda9bac49039847a7ed20c1d966766ecc64a/scripts/coverage.js
 


### PR DESCRIPTION
We will be migrating the repository to Buidler (and Hardhat after #541 lands :slightly_smiling_face:), and I don't want this link to become broken.