### PR TITLE
Use real Zeppelin (instead of fork) as E2E

### DIFF
--- a/scripts/run-zeppelin.sh
+++ b/scripts/run-zeppelin.sh
@@ -20,21 +20,22 @@ fi
 
 echo "PR_PATH >>>>> $PR_PATH"
 
-npm install -g yarn;
-
 # Install Zeppelin
 git clone https://github.com/OpenZeppelin/openzeppelin-contracts.git
 cd openzeppelin-contracts
 
 # Swap installed coverage for PR branch version
 echo ">>>>> yarn install"
-yarn install
+npm install
 
-echo ">>>>> yarn remove solidity-coverage --dev"
-yarn remove solidity-coverage --dev
+echo ">>>>> npm uninstall solidity-coverage --save-dev"
+npm uninstall solidity-coverage --save-dev
 
 echo ">>>>> yarn add $PR_PATH --dev"
-yarn add "$PR_PATH" --dev
+npm install "$PR_PATH" --save-dev
+
+echo ">>>>> cat package.json"
+cat package.json
 
 # Track perf
 time npx buidler coverage

--- a/scripts/run-zeppelin.sh
+++ b/scripts/run-zeppelin.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# E2E CI: installs PR candidate on openzeppelin-solidity and runs coverage
+# E2E CI: installs PR candidate on openzeppelin-contracts and runs coverage
 #
 
 set -o errexit
@@ -22,24 +22,19 @@ echo "PR_PATH >>>>> $PR_PATH"
 
 npm install -g yarn;
 
-# Install sc-forks Zeppelin fork (temporarily). It's setup to
-# consume the plugin and skips a small set of GSN tests that rely on
-# the client being stand-alone. (See OZ issue #1918 for discussion)
-git clone https://github.com/sc-forks/openzeppelin-contracts.git
+# Install Zeppelin
+git clone https://github.com/OpenZeppelin/openzeppelin-contracts.git
 cd openzeppelin-contracts
-
-echo ">>>>> checkout provider-benchmarks branch"
-git checkout provider-benchmarks
 
 # Swap installed coverage for PR branch version
 echo ">>>>> yarn install"
 yarn install
 
-echo ">>>>> yarn remove --dev solidity-coverage"
+echo ">>>>> yarn remove solidity-coverage --dev"
 yarn remove solidity-coverage --dev
 
-echo ">>>>> yarn add -dev $PR_PATH"
+echo ">>>>> yarn add $PR_PATH --dev"
 yarn add "$PR_PATH" --dev
 
 # Track perf
-time npx truffle run coverage --network development
+time npx buidler coverage

--- a/scripts/run-zeppelin.sh
+++ b/scripts/run-zeppelin.sh
@@ -25,13 +25,13 @@ git clone https://github.com/OpenZeppelin/openzeppelin-contracts.git
 cd openzeppelin-contracts
 
 # Swap installed coverage for PR branch version
-echo ">>>>> yarn install"
+echo ">>>>> npm install"
 npm install
 
 echo ">>>>> npm uninstall solidity-coverage --save-dev"
 npm uninstall solidity-coverage --save-dev
 
-echo ">>>>> yarn add $PR_PATH --dev"
+echo ">>>>> npm add $PR_PATH --dev"
 npm install "$PR_PATH" --save-dev
 
 echo ">>>>> cat package.json"

--- a/scripts/run-zeppelin.sh
+++ b/scripts/run-zeppelin.sh
@@ -38,4 +38,4 @@ echo ">>>>> cat package.json"
 cat package.json
 
 # Track perf
-time npx buidler coverage
+CI=false npm run coverage


### PR DESCRIPTION
Closes #555 

This should seamlessly become the Hardhat E2E when they go up. 

**Notes**
+ Their codecov command is exiting `0` without uploading reports (good)
+  Initially installed with yarn (ignoring the package-lock) and the test run took [twice as long][1] (20m vs 10m). Something's going on there maybe.

[1]: https://app.circleci.com/pipelines/github/sc-forks/solidity-coverage/161/workflows/adbac833-24a4-4422-9561-f041130f6ebe/jobs/2566
