### PR TITLE
Disable temp folder logic for hardhat >= 2.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "pify": "^4.0.1",
     "recursive-readdir": "^2.2.2",
     "sc-istanbul": "^0.4.5",
+    "semver": "^7.3.4",
     "shelljs": "^0.8.3",
     "web3-utils": "^1.3.0"
   },
@@ -52,7 +53,7 @@
     "@truffle/contract": "^4.0.36",
     "buidler-gas-reporter": "^0.1.3",
     "decache": "^4.5.1",
-    "hardhat": "^2.0.2",
+    "hardhat": "2.0.2",
     "hardhat-gas-reporter": "^1.0.1",
     "mocha": "5.2.0",
     "nyc": "^14.1.1",

--- a/plugins/hardhat.plugin.js
+++ b/plugins/hardhat.plugin.js
@@ -128,15 +128,19 @@ task("coverage", "Generates a code coverage report for tests")
 
     config.temp = args.temp;
 
-    const {
-      tempArtifactsDir,
-      tempContractsDir
-    } = utils.getTempLocations(config);
+    // With Hardhat >= 2.0.4, everything should automatically recompile
+    // after solidity-coverage corrupts the artifacts.
+    // Prior to that version, we (try to) save artifacts to a temp folder.
+    if (!config.useHardhatDefaultPaths){
+      const {
+        tempArtifactsDir,
+        tempContractsDir
+      } = utils.getTempLocations(config);
 
-    utils.setupTempFolders(config, tempContractsDir, tempArtifactsDir)
-
-    config.paths.artifacts = tempArtifactsDir;
-    config.paths.cache = nomiclabsUtils.tempCacheDir(config);
+      utils.setupTempFolders(config, tempContractsDir, tempArtifactsDir)
+      config.paths.artifacts = tempArtifactsDir;
+      config.paths.cache = nomiclabsUtils.tempCacheDir(config);
+    }
 
     await env.run(TASK_COMPILE);
 

--- a/plugins/resources/nomiclabs.utils.js
+++ b/plugins/resources/nomiclabs.utils.js
@@ -3,6 +3,7 @@ const globby = require('globby');
 const pluginUtils = require("./plugin.utils");
 const path = require('path');
 const DataCollector = require("./../../lib/collector")
+const semver = require("semver")
 const util = require('util')
 
 // =============================
@@ -36,6 +37,13 @@ function normalizeConfig(config, args={}){
   config.logger = config.logger ? config.logger : {log: null};
   config.solcoverjs = args.solcoverjs
   config.gasReporter = { enabled: false }
+
+  try {
+    const hardhatPackage = require('hardhat/package.json');
+    if (semver.gt(hardhatPackage.version, '2.0.3')){
+      config.useHardhatDefaultPaths = true;
+    }
+  } catch(e){ /* ignore */ }
 
   return config;
 }

--- a/scripts/run-nomiclabs.sh
+++ b/scripts/run-nomiclabs.sh
@@ -66,6 +66,27 @@ npx hardhat coverage
 
 verifyCoverageExists
 
+echo ""
+echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
+echo "wighawag/hardhat-deploy                "
+echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
+echo ""
+cd ..
+git clone https://github.com/cgewecke/template-ethereum-contracts.git
+cd template-ethereum-contracts
+yarn
+yarn add $PR_PATH --dev
+cat package.json
+
+# Here we want to make sure that HH cache triggers a
+# complete recompile after coverage runs by verifying
+# that gas consumption is same in both runs.
+yarn run gas
+yarn run coverage
+yarn run gas
+
+verifyCoverageExists
+
 # Install buidler-ethers
 echo ""
 echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"

--- a/scripts/run-nomiclabs.sh
+++ b/scripts/run-nomiclabs.sh
@@ -72,6 +72,7 @@ echo "wighawag/hardhat-deploy                "
 echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
 echo ""
 cd ..
+npm install -g yarn
 git clone https://github.com/cgewecke/template-ethereum-contracts.git
 cd template-ethereum-contracts
 yarn

--- a/yarn.lock
+++ b/yarn.lock
@@ -3139,7 +3139,7 @@ hardhat-gas-reporter@^1.0.1:
   dependencies:
     eth-gas-reporter "^0.2.19"
 
-hardhat@^2.0.2:
+hardhat@2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/hardhat/-/hardhat-2.0.2.tgz#30c3c5a49f950aad2e39c479208b4132052dc735"
   dependencies:
@@ -3949,6 +3949,12 @@ lru-cache@^5.1.1:
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-5.1.1.tgz#1da27e6710271947695daf6848e847f01d84b920"
   dependencies:
     yallist "^3.0.2"
+
+lru-cache@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
+  dependencies:
+    yallist "^4.0.0"
 
 lru_map@^0.3.3:
   version "0.3.3"
@@ -5302,6 +5308,12 @@ semver@^5.7.0:
 semver@^6.0.0, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
+
+semver@^7.3.4:
+  version "7.3.4"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.4.tgz#27aaa7d2e4ca76452f98d3add093a72c943edc97"
+  dependencies:
+    lru-cache "^6.0.0"
 
 semver@~5.4.1:
   version "5.4.1"
@@ -6930,6 +6942,10 @@ yallist@^2.1.2:
 yallist@^3.0.0, yallist@^3.0.2, yallist@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.0.3.tgz#b4b049e314be545e3ce802236d6cd22cd91c3de9"
+
+yallist@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
 
 yargs-parser@13.1.2, yargs-parser@^13.1.2:
   version "13.1.2"


### PR DESCRIPTION
#580 
#573 

Also adds an integration using (fork of) wighawags [template-ethereum-contracts][1] in order to verify everything works ok w/ hardhat-deploy.

Coverage dropped because there is hardhat version dependent logic that we check in the nomiclabs integration tests which doesn't make it to the report.


