### PR TITLE
Suppress compilation warnings introduced by injected trace statements

### DIFF
--- a/plugins/hardhat.plugin.js
+++ b/plugins/hardhat.plugin.js
@@ -14,6 +14,7 @@ const {
   TASK_COMPILE,
   TASK_COMPILE_SOLIDITY_GET_COMPILER_INPUT,
   TASK_COMPILE_SOLIDITY_GET_COMPILATION_JOB_FOR_FILE,
+  TASK_COMPILE_SOLIDITY_LOG_COMPILATION_ERRORS
 } = require("hardhat/builtin-tasks/task-names");
 
 // Toggled true for `coverage` task only.
@@ -60,6 +61,18 @@ task(TASK_COMPILE_SOLIDITY_GET_COMPILATION_JOB_FOR_FILE).setAction(async (_, __,
     settings.optimizer.enabled = false;
   }
   return compilationJob;
+});
+
+// Suppress compilation warnings because injected trace function triggers
+// complaint about unused variable
+subtask(TASK_COMPILE_SOLIDITY_LOG_COMPILATION_ERRORS).setAction(async (_, __, runSuper) => {
+  const defaultWarn = console.warn;
+
+  if (measureCoverage) {
+    console.warn = () => {};
+  }
+  await runSuper();
+  console.warn = defaultWarn;
 });
 
 /**

--- a/plugins/resources/truffle.utils.js
+++ b/plugins/resources/truffle.utils.js
@@ -208,10 +208,29 @@ function normalizeConfig(config){
   return config;
 }
 
+/**
+ * Replacement logger which filters out compilation warnings triggered by injected trace
+ * function definitions.
+ *
+ * @type {Object}
+ */
+const filteredLogger = {
+  log: (val) => {
+    const loggable = typeof val === 'string'   &&
+                     !val.includes('Warning:') && // solc msg grep
+                     !process.env.SILENT;         // unit tests
+
+    loggable && console.log(val);
+  },
+  warn: console.warn,
+  error: console.error
+}
+
 module.exports = {
   getTestFilePaths,
   setNetwork,
   setNetworkFrom,
   loadLibrary,
   normalizeConfig,
+  filteredLogger
 }

--- a/plugins/truffle.plugin.js
+++ b/plugins/truffle.plugin.js
@@ -90,11 +90,20 @@ async function plugin(config){
       path.basename(config.contracts_build_directory)
     );
 
+    // Filter compilation warnings
+    const defaultLogger = config.logger;
+    if (!config.verbose){
+      config.logger = truffleUtils.filteredLogger;
+    }
+
     config.all = true;
+    config.strict = false;
     config.compilers.solc.settings.optimizer.enabled = false;
 
     // Compile Instrumented Contracts
     await truffle.contracts.compile(config);
+    config.logger = defaultLogger;
+
     await api.onCompileComplete(config);
 
     config.test_files = await truffleUtils.getTestFilePaths(config);

--- a/test/units/truffle/flags.js
+++ b/test/units/truffle/flags.js
@@ -204,6 +204,7 @@ describe('Truffle Plugin: command line options', function() {
     truffleConfig.logger = mock.testLogger;
 
     truffleConfig.temp = 'special_location';
+    truffleConfig.verbose = true;
 
     mock.install('Simple', 'simple.js', solcoverConfig);
     await plugin(truffleConfig);


### PR DESCRIPTION
The logical OR tracer def triggers:
```
.coverage_contracts/Simple.sol:6:27: Warning: Unused function parameter. Remove or comment out the variable name to silence this warning.
function c_true0x08454fe6(bytes32 c__0x08454fe6) public pure returns (bool){ return true; }
```
