### PR TITLE
Use bytes8 instead of bytes32 as hash key

### DIFF
--- a/lib/collector.js
+++ b/lib/collector.js
@@ -53,17 +53,17 @@ class DataCollector {
   }
 
   /**
-   * Left-pads zero prefixed bytes 32 hashes to length 66. The '59' in the
+   * Left-pads zero prefixed bytes8 hashes to length 18. The '11' in the
    * comparison below is arbitrary. It provides a margin for recurring zeros
-   * but prevents left-padding shorter irrelevant hashes (like fn sigs)
+   * but prevents left-padding shorter irrelevant hashes
    *
    * @param  {String} hash  data hash from evm stack.
    * @return {String}       0x prefixed hash of length 66.
    */
   _normalizeHash(hash){
-    if (hash.length < 66 && hash.length > 59){
+    if (hash.length < 18 && hash.length > 11){
       hash = hash.slice(2);
-      while(hash.length < 64) hash = '0' + hash;
+      while(hash.length < 16) hash = '0' + hash;
       hash = '0x' + hash
     }
     return hash;

--- a/lib/coverage.js
+++ b/lib/coverage.js
@@ -75,14 +75,14 @@ class Coverage {
       const hits = collectedData[hash].hits;
 
       switch(collectedData[hash].type){
-        case 'line':       this.data[contractPath].l[id] = hits;                       break;
-        case 'function':   this.data[contractPath].f[id] = hits;                       break;
-        case 'statement':  this.data[contractPath].s[id] = hits;                       break;
-        case 'branch':     this.data[contractPath].b[id][data.locationIdx] = hits;     break;
-        case 'and-true':   this.data[contractPath].b[id][data.locationIdx] = hits / 2; break;
-        case 'or-false':   this.data[contractPath].b[id][data.locationIdx] = hits / 2; break;
-        case 'requirePre':  this.requireData[contractPath][id].preEvents = hits;     break;
-        case 'requirePost': this.requireData[contractPath][id].postEvents = hits;    break;
+        case 'line':       this.data[contractPath].l[id] = hits;                   break;
+        case 'function':   this.data[contractPath].f[id] = hits;                   break;
+        case 'statement':  this.data[contractPath].s[id] = hits;                   break;
+        case 'branch':     this.data[contractPath].b[id][data.locationIdx] = hits; break;
+        case 'and-true':   this.data[contractPath].b[id][data.locationIdx] = hits; break;
+        case 'or-false':   this.data[contractPath].b[id][data.locationIdx] = hits; break;
+        case 'requirePre':  this.requireData[contractPath][id].preEvents = hits;   break;
+        case 'requirePost': this.requireData[contractPath][id].postEvents = hits;  break;
       }
     }
 

--- a/lib/injector.js
+++ b/lib/injector.js
@@ -28,26 +28,26 @@ class Injector {
 
   _getHash(id) {
     this.hashCounter++;
-    return web3Utils.keccak256(`${id}:${this.hashCounter}`);
+    return web3Utils.keccak256(`${id}:${this.hashCounter}`).slice(0,18);
   }
 
   // Method returns void
   _getDefaultMethodIdentifier(id){
-    return `c_${web3Utils.keccak256(id).slice(0,10)}`
+    return `c_${web3Utils.keccak256(id).slice(2,10)}`
   }
 
   // Method returns boolean: true
   _getTrueMethodIdentifier(id){
-    return `c_true${web3Utils.keccak256(id).slice(0,10)}`
+    return `c_true${web3Utils.keccak256(id).slice(2,10)}`
   }
 
   // Method returns boolean: false
   _getFalseMethodIdentifier(id){
-    return `c_false${web3Utils.keccak256(id).slice(0,10)}`
+    return `c_false${web3Utils.keccak256(id).slice(2,10)}`
   }
 
   _getModifierIdentifier(id){
-    return `c_mod${web3Utils.keccak256(id).slice(0,10)}`
+    return `c_mod${web3Utils.keccak256(id).slice(2,10)}`
   }
 
   _getInjectionComponents(contract, injectionPoint, id, type){
@@ -70,9 +70,9 @@ class Injector {
    * @return {String}          ex: bytes32[1] memory _sc_82e0891
    */
   _getDefaultMethodDefinition(id){
-    const hash = web3Utils.keccak256(id).slice(0,10);
+    const hash = web3Utils.keccak256(id).slice(2,10);
     const method = this._getDefaultMethodIdentifier(id);
-    return `\nfunction ${method}(bytes32 c__${hash}) public pure {}\n`;
+    return `\nfunction ${method}(bytes8 c__${hash}) public pure {}\n`;
   }
 
   /**
@@ -82,9 +82,9 @@ class Injector {
    * @return {String}          ex: bytes32[1] memory _sc_82e0891
    */
   _getTrueMethodDefinition(id){
-    const hash = web3Utils.keccak256(id).slice(0,10);
+    const hash = web3Utils.keccak256(id).slice(2,10);
     const method = this._getTrueMethodIdentifier(id);
-    return `function ${method}(bytes32 c__${hash}) public pure returns (bool){ return true; }\n`;
+    return `function ${method}(bytes8 c__${hash}) public pure returns (bool){ return true; }\n`;
   }
 
   /**
@@ -94,9 +94,9 @@ class Injector {
    * @return {String}          ex: bytes32[1] memory _sc_82e0891
    */
   _getFalseMethodDefinition(id){
-    const hash = web3Utils.keccak256(id).slice(0,10);
+    const hash = web3Utils.keccak256(id).slice(2,10);
     const method = this._getFalseMethodIdentifier(id);
-    return `function ${method}(bytes32 c__${hash}) public pure returns (bool){ return false; }\n`;
+    return `function ${method}(bytes8 c__${hash}) public pure returns (bool){ return false; }\n`;
   }
 
   _getModifierDefinitions(contractId, instrumentation){


### PR DESCRIPTION
This should reduce the instrumentation text-size footprint a quite a bit. 