### PR TITLE
Fix pre/post strategy for modifier coverage

### DIFF
--- a/lib/injector.js
+++ b/lib/injector.js
@@ -108,30 +108,20 @@ class Injector {
         injection += `modifier ${this._getModifierIdentifier(item.modifierId)}{ `;
 
         let hash = this._getHash(item.modifierId);
-        let injectable = this._getInjectable(item.contractId, hash, 'modifier-pre');
+        let comment = `modifier-${item.condition}`;
+        let injectable = this._getInjectable(item.contractId, hash, comment);
+
+        // Process modifiers in the same step as `require` stmts in coverage.js
+        let type = (item.condition === 'pre') ? 'requirePre' : 'requirePost';
 
         instrumentation[hash] = {
           id: item.branchId,
-          type: 'requirePre',
+          type: type,
           contractPath: item.fileName,
           hits: 0
         }
 
-        injection += injectable;
-        injection += `_;`
-
-        hash = this._getHash(item.modifierId);
-        injectable = this._getInjectable(item.contractId, hash, 'modifier-post');
-
-        instrumentation[hash] = {
-          id: item.branchId,
-          type: 'requirePost',
-          contractPath: item.fileName,
-          hits: 0
-        }
-
-        injection += injectable;
-        injection += ` }\n`;
+        injection += `${injectable} _; }\n`;
       }
     }
 
@@ -366,7 +356,8 @@ class Injector {
     const type = 'modifier';
     const contractId = `${fileName}:${injection.contractName}`;
     const modifierId = `${fileName}:${injection.contractName}:` +
-                       `${injection.modifierName}:${injection.fnId}`;
+                       `${injection.modifierName}:${injection.fnId}:` +
+                       `${injection.condition}`;
 
     const {
       start,

--- a/lib/registrar.js
+++ b/lib/registrar.js
@@ -131,7 +131,7 @@ class Registrar {
         // Add modifier branch coverage
         if (!this.enabled.modifiers || expression.isConstructor) continue;
 
-        this.addNewModifierBranch(contract, modifier);
+        this.addNewBranch(contract, modifier);
         this._createInjectionPoint(
           contract,
           modifier.range[0],
@@ -139,7 +139,19 @@ class Registrar {
             type: 'injectModifier',
             branchId: contract.branchId,
             modifierName: modifier.name,
-            fnId: contract.fnId
+            fnId: contract.fnId,
+            condition: 'pre'
+          }
+        );
+        this._createInjectionPoint(
+          contract,
+          modifier.range[1] + 1,
+          {
+            type: 'injectModifier',
+            branchId: contract.branchId,
+            modifierName: modifier.name,
+            fnId: contract.fnId,
+            condition: 'post'
           }
         );
       }
@@ -180,41 +192,6 @@ class Registrar {
    * @param  {Object} expression AST node
    */
   addNewBranch(contract, expression) {
-    const startContract = contract.instrumented.slice(0, expression.range[0]);
-    const startline = ( startContract.match(/\n/g) || [] ).length + 1;
-    const startcol = expression.range[0] - startContract.lastIndexOf('\n') - 1;
-
-    contract.branchId += 1;
-
-    // NB locations for if branches in istanbul are zero
-    // length and associated with the start of the if.
-    contract.branchMap[contract.branchId] = {
-      line: startline,
-      type: 'if',
-      locations: [{
-        start: {
-          line: startline, column: startcol,
-        },
-        end: {
-          line: startline, column: startcol,
-        },
-      }, {
-        start: {
-          line: startline, column: startcol,
-        },
-        end: {
-          line: startline, column: startcol,
-        },
-      }],
-    };
-  };
-
-  /**
-   * Registers injections for modifier branch measurements.
-   * @param  {Object} contract   instrumentation target
-   * @param  {Object} expression AST node
-   */
-  addNewModifierBranch(contract, expression) {
     const startContract = contract.instrumented.slice(0, expression.range[0]);
     const startline = ( startContract.match(/\n/g) || [] ).length + 1;
     const startcol = expression.range[0] - startContract.lastIndexOf('\n') - 1;

--- a/plugins/resources/plugin.utils.js
+++ b/plugins/resources/plugin.utils.js
@@ -222,13 +222,6 @@ function loadSolcoverJS(config={}){
   coverageConfig.cwd = config.workingDir;
   coverageConfig.originalContractsDir = config.contractsDir;
 
-  if (config.matrix){
-    coverageConfig.measureBranchCoverage = false;
-    coverageConfig.measureFunctionCoverage = false;
-    coverageConfig.measureModifierCoverage = false;
-    coverageConfig.measureStatementCoverage = false;
-  }
-
   // Solidity-Coverage writes to Truffle config
   config.mocha = config.mocha || {};
 

--- a/test/sources/solidity/contracts/modifiers/reverting-fn.sol
+++ b/test/sources/solidity/contracts/modifiers/reverting-fn.sol
@@ -1,0 +1,14 @@
+pragma solidity ^0.7.0;
+
+contract Test {
+    bool flag = true;
+
+    modifier m {
+      require(flag);
+      _;
+    }
+
+    function a(bool success) m public {
+        require(success);
+    }
+}

--- a/test/sources/solidity/contracts/modifiers/reverting-neighbor.sol
+++ b/test/sources/solidity/contracts/modifiers/reverting-neighbor.sol
@@ -1,0 +1,23 @@
+pragma solidity ^0.7.0;
+
+contract Test {
+    bool flag = true;
+
+    modifier m {
+      require(true);
+      _;
+    }
+
+    modifier n {
+      require(flag);
+      _;
+    }
+
+    function flip() public {
+      flag = !flag;
+    }
+
+    function a() m n public {
+      uint x = 5;
+    }
+}


### PR DESCRIPTION
PR fixes two problems discovered running [dForceLending][1]
+ Modifier branches were not isolated from reverts downstream from them, resulting in false branch hits. New strategy is to have the post-condition as its own modifier, instead of positioning it after the `_;`
+ Matrix is not being generated correctly when only line coverage is enabled. Not certain what's going wrong here, just disabled the disabling for now since there's no obvious slowdown on a project that size.

[1]: https://github.com/dforce-network/dForceLending