### PR TITLE
Allow duplicate modifiers on same function

### DIFF
--- a/lib/injector.js
+++ b/lib/injector.js
@@ -3,6 +3,7 @@ const web3Utils = require("web3-utils");
 class Injector {
   constructor(){
     this.hashCounter = 0;
+    this.modifierCounter = 0;
     this.modifiers = {};
   }
 
@@ -353,11 +354,13 @@ class Injector {
   }
 
   injectModifier(contract, fileName, injectionPoint, injection, instrumentation){
+    this.modifierCounter++;
+
     const type = 'modifier';
     const contractId = `${fileName}:${injection.contractName}`;
     const modifierId = `${fileName}:${injection.contractName}:` +
                        `${injection.modifierName}:${injection.fnId}:` +
-                       `${injection.condition}`;
+                       `${injection.condition}:${this.modifierCounter}`;
 
     const {
       start,

--- a/test/sources/solidity/contracts/modifiers/duplicate-mods-same-fn.sol
+++ b/test/sources/solidity/contracts/modifiers/duplicate-mods-same-fn.sol
@@ -1,0 +1,15 @@
+pragma solidity ^0.7.0;
+
+contract Test {
+    modifier m(string memory val) {
+      _;
+    }
+
+    function a()
+      m('ETH')
+      m('BTC')
+      public
+    {
+      uint x = 5;
+    }
+}

--- a/test/units/modifiers.js
+++ b/test/units/modifiers.js
@@ -216,6 +216,23 @@ describe('modifiers', () => {
     });
   });
 
+  it('should cover when same modifier is invoked twice on same fn', async function() {
+    const mapping = await setupAndRun('modifiers/duplicate-mods-same-fn');
+
+    assert.deepEqual(mapping[util.filePath].l, {
+      "5":2,"13":1
+    });
+    assert.deepEqual(mapping[util.filePath].b, {
+      "1":[1,0],"2":[1,0]
+    });
+    assert.deepEqual(mapping[util.filePath].s, {
+      1: 1
+    });
+    assert.deepEqual(mapping[util.filePath].f, {
+      1: 2, 2: 1
+    });
+  });
+
   it('should *not* treat constructor inheritance invocations as branches', async function() {
     const mapping = await setupAndRun('modifiers/constructor');
     assert.deepEqual(mapping[util.filePath].b, {});


### PR DESCRIPTION
Fixes a bug found running Synthetix where modifiers are invoked twice in the same function header, e.g
```solidity
    function exchangeEtherForSNX()
        external
        payable
        rateNotInvalid(SNX)
        rateNotInvalid(ETH)
        notPaused
        returns (
            uint // Returns the number of SNX received
        )
    {
        return _exchangeEtherForSNX();
    }
```

PR disambiguates these using a counter. 