### PR TITLE
Add modifierWhitelist option

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ module.exports = {
 | measureStatementCoverage | *boolean* | `true` | Computes statement (in addition to line) coverage. [More...][34] |
 | measureFunctionCoverage | *boolean* | `true` | Computes function coverage. [More...][34] |
 | measureModifierCoverage | *boolean* | `true` | Computes each modifier invocation as a code branch. [More...][34] |
+| modifierWhitelist | *String[]* | `[]` | List of modifier names (ex: "onlyOwner") to exclude from branch measurement. (Useful for modifiers which prepare something instead of acting as a gate.)) |
 | matrixOutputPath | *String* | `./testMatrix.json` | Relative path to write test matrix JSON object to. [More...][38] |
 | istanbulFolder | *String* | `./coverage` |  Folder location for Istanbul coverage reports. |
 | istanbulReporter | *Array* | `['html', 'lcov', 'text', 'json']` | [Istanbul coverage reporters][2]  |

--- a/lib/instrumenter.js
+++ b/lib/instrumenter.js
@@ -15,6 +15,7 @@ class Instrumenter {
   constructor(config={}){
     this.instrumentationData = {};
     this.injector = new Injector();
+    this.modifierWhitelist = config.modifierWhitelist || [];
     this.enabled = {
       statements: (config.measureStatementCoverage === false) ? false : true,
       functions: (config.measureFunctionCoverage === false) ? false: true,
@@ -62,7 +63,7 @@ class Instrumenter {
     const contract = {};
 
     this.injector.resetModifierMapping();
-    parse.configure(this.enabled);
+    parse.configure(this.enabled, this.modifierWhitelist);
 
     contract.source = contractSource;
     contract.instrumented = contractSource;

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -9,8 +9,9 @@ const register = new Registrar();
 const parse = {};
 
 // Utilities
-parse.configure = function(_enabled){
+parse.configure = function(_enabled, _whitelist){
   register.enabled = Object.assign(register.enabled, _enabled);
+  register.modifierWhitelist = _whitelist;
 }
 
 // Nodes

--- a/lib/registrar.js
+++ b/lib/registrar.js
@@ -19,6 +19,8 @@ class Registrar {
       branches: true,
       lines: true
     }
+
+    this.modifierWhitelist = [];
   }
 
   /**
@@ -129,7 +131,13 @@ class Registrar {
         }
 
         // Add modifier branch coverage
-        if (!this.enabled.modifiers || expression.isConstructor) continue;
+        if (
+          !this.enabled.modifiers   ||
+          expression.isConstructor  ||
+          this.modifierWhitelist.includes(modifier.name)
+        ) {
+          continue;
+        }
 
         this.addNewBranch(contract, modifier);
         this._createInjectionPoint(

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -42,6 +42,11 @@ const configSchema = {
       type: "array",
       items: {type: "string"}
     },
+
+    modifierWhitelist: {
+      type: "array",
+      items: {type: "string"}
+    }
   },
 };
 

--- a/test/units/modifiers.js
+++ b/test/units/modifiers.js
@@ -13,7 +13,10 @@ describe('modifiers', () => {
     api = new Api({silent: true});
     await api.ganache(client);
   })
-  beforeEach(() => coverage = new Coverage());
+  beforeEach(() => {
+    api.config = {};
+    coverage = new Coverage()
+  });
   after(async() => await api.finish());
 
   async function setupAndRun(solidityFile){
@@ -88,6 +91,25 @@ describe('modifiers', () => {
     });
     assert.deepEqual(mapping[util.filePath].b, {
       1: [1, 0], 2: [1, 0], 3: [1, 0], 4: [1, 0]
+    });
+    assert.deepEqual(mapping[util.filePath].s, {
+      1: 1, 2: 1, 3: 1
+    });
+    assert.deepEqual(mapping[util.filePath].f, {
+      1: 1, 2: 1, 3: 1
+    });
+  });
+
+  // Same test as above - should have 2 fewer branches
+  it('should exclude whitelisted modifiers', async function() {
+    api.config.modifierWhitelist = ['mmm', 'nnn'];
+    const mapping = await setupAndRun('modifiers/multiple-mods-same-fn');
+
+    assert.deepEqual(mapping[util.filePath].l, {
+      5: 1, 6: 1, 10: 1, 11: 1, 15: 1
+    });
+    assert.deepEqual(mapping[util.filePath].b, {
+      1: [1, 0], 2: [1, 0]
     });
     assert.deepEqual(mapping[util.filePath].s, {
       1: 1, 2: 1, 3: 1

--- a/test/units/validator.js
+++ b/test/units/validator.js
@@ -119,6 +119,7 @@ describe('config validation', () => {
     const options =  [
       "skipFiles",
       "istanbulReporter",
+      "modifierWhitelist"
     ]
 
     options.forEach(name => {


### PR DESCRIPTION
Option accepts a list of strings (simple modifier names like `nonReentrant`) to exclude from modifier branch coverage. 

This is useful for modifiers that perform non-branch preparatory work. 

Ex: `synthetix/Proxyable:optionalProxy`
```solidity
    modifier optionalProxy {
        _optionalProxy();
        _;
    }


    function _optionalProxy() private {
        if (Proxy(msg.sender) != proxy && Proxy(msg.sender) != integrationProxy && messageSender != msg.sender) {
            messageSender = msg.sender;
        }
    }
```