### PR TITLE
Fixing a bug for function definition

### DIFF
--- a/lib/registrar.js
+++ b/lib/registrar.js
@@ -115,8 +115,8 @@ class Registrar {
     // which contains an open curly brace. Skip ahead...
     if (expression.modifiers && expression.modifiers.length){
       for (let modifier of expression.modifiers ){
-        if (modifier.range[1] > start){
-          start = modifier.range[1];
+        if (modifier.range[1]+1 > start){
+          start = modifier.range[1]+1;
         }
       }
     } else {


### PR DESCRIPTION
The function defintion should start one posiiton after the end of the modifier.
Given a function "function method() onlyOwner {...}', the current version of the return the definition "r{...}" instead of "{...}". I notice the same error happens when a function uses a modifier: the last character of the modifier is added to the  parsed definiton.

This commit fixes the bug.