### PR TITLE
Add missing hardhat network variables

### DIFF
--- a/plugins/resources/nomiclabs.utils.js
+++ b/plugins/resources/nomiclabs.utils.js
@@ -134,6 +134,7 @@ function configureNetworkEnv(env, networkName, networkConfig, provider, isHardha
   env.config.defaultNetwork = networkName;
 
   env.network = {
+    ...env.network,
     name: networkName,
     config: networkConfig,
     provider: provider,


### PR DESCRIPTION
Fixes https://github.com/sc-forks/solidity-coverage/issues/624 and https://github.com/wighawag/hardhat-deploy/issues/132

Proposed fix inspired from discussions in `hardhat-deploy` issue 132