### PR TITLE
Override subtasks as subtasks, not tasks

### DIFF
--- a/plugins/hardhat.plugin.js
+++ b/plugins/hardhat.plugin.js
@@ -23,7 +23,7 @@ let instrumentedSources
 // UI for the task flags...
 const ui = new PluginUI();
 
-task(TASK_COMPILE_SOLIDITY_GET_COMPILER_INPUT).setAction(async (_, { config }, runSuper) => {
+subtask(TASK_COMPILE_SOLIDITY_GET_COMPILER_INPUT).setAction(async (_, { config }, runSuper) => {
   const solcInput = await runSuper();
   if (measureCoverage) {
     // The source name here is actually the global name in the solc input,
@@ -40,7 +40,7 @@ task(TASK_COMPILE_SOLIDITY_GET_COMPILER_INPUT).setAction(async (_, { config }, r
 });
 
 // Solidity settings are best set here instead of the TASK_COMPILE_SOLIDITY_GET_COMPILER_INPUT task.
-task(TASK_COMPILE_SOLIDITY_GET_COMPILATION_JOB_FOR_FILE).setAction(async (_, __, runSuper) => {
+subtask(TASK_COMPILE_SOLIDITY_GET_COMPILATION_JOB_FOR_FILE).setAction(async (_, __, runSuper) => {
   const compilationJob = await runSuper();
   if (measureCoverage && typeof compilationJob === "object") {
     if (compilationJob.solidityConfig.settings === undefined) {


### PR DESCRIPTION
Before this change, the hardhat help printer was including these tasks as top-level tasks rather than excluding them from the output like sub-tasks get excluded:

```
$ yarn hardhat
yarn run v1.22.11
$ /home/gene/dev/geneAum/hardhat-empty/node_modules/.bin/hardhat
183902c7-780d-45b2-8153-d82bdca11490
Hardhat version 2.5.0

Usage: hardhat [GLOBAL OPTIONS] <TASK> [TASK OPTIONS]

GLOBAL OPTIONS:

  --config           	A Hardhat config file. 
  --emoji            	Use emoji in messages. 
  --help             	Shows this message, or a task's help if its name is provided 
  --max-memory       	The maximum amount of memory that Hardhat can use. 
  --network          	The network to connect to. 
  --show-stack-traces	Show stack traces. 
  --tsconfig         	Reserved hardhat argument -- Has no effect. 
  --verbose          	Enables Hardhat verbose logging 
  --version          	Shows hardhat's version. 


AVAILABLE TASKS:

  accounts                                     	Prints the list of accounts
  check                                        	Check whatever you need
  clean                                        	Clears the cache and deletes all artifacts
  compile                                      	Compiles the entire project, building all artifacts
  compile:solidity:get-compilation-job-for-file	
  compile:solidity:get-compiler-input          	
  console                                      	Opens a hardhat console
  coverage                                     	Generates a code coverage report for tests
  flatten                                      	Flattens and prints contracts and their dependencies
  help                                         	Prints this message
  node                                         	Starts a JSON-RPC server on top of Hardhat Network
  run                                          	Runs a user-defined script after compiling the project
  test                                         	Runs mocha tests
  typechain                                    	Generate Typechain typings for compiled contracts
  verify                                       	Verifies contract on Etherscan

To get help for a specific task run: npx hardhat help [task]

Done in 2.82s.
```

After these changes, these sub-tasks are being hidden properly:

```
$ yarn hardhat
yarn run v1.22.11
$ /home/gene/dev/geneAum/hardhat-empty/node_modules/.bin/hardhat
183902c7-780d-45b2-8153-d82bdca11490
Hardhat version 2.5.0

Usage: hardhat [GLOBAL OPTIONS] <TASK> [TASK OPTIONS]

GLOBAL OPTIONS:

  --config           	A Hardhat config file. 
  --emoji            	Use emoji in messages. 
  --help             	Shows this message, or a task's help if its name is provided 
  --max-memory       	The maximum amount of memory that Hardhat can use. 
  --network          	The network to connect to. 
  --show-stack-traces	Show stack traces. 
  --tsconfig         	Reserved hardhat argument -- Has no effect. 
  --verbose          	Enables Hardhat verbose logging 
  --version          	Shows hardhat's version. 


AVAILABLE TASKS:

  accounts 	Prints the list of accounts
  check    	Check whatever you need
  clean    	Clears the cache and deletes all artifacts
  compile  	Compiles the entire project, building all artifacts
  console  	Opens a hardhat console
  coverage 	Generates a code coverage report for tests
  flatten  	Flattens and prints contracts and their dependencies
  help     	Prints this message
  node     	Starts a JSON-RPC server on top of Hardhat Network
  run      	Runs a user-defined script after compiling the project
  test     	Runs mocha tests
  typechain	Generate Typechain typings for compiled contracts
  verify   	Verifies contract on Etherscan

To get help for a specific task run: npx hardhat help [task]

Done in 2.77s.
```