### PR TITLE
Use internal visibility for fn level hash method defs

### DIFF
--- a/lib/injector.js
+++ b/lib/injector.js
@@ -47,7 +47,7 @@ class Injector {
   _getHashMethodDefinition(id, contract){
     const hash = web3Utils.keccak256(id).slice(0,10);
     const method = this._getMethodIdentifier(id);
-    return `\nfunction ${method}(bytes32 c__${hash}) public pure {}\n`;
+    return `\nfunction ${method}(bytes32 c__${hash}) internal pure {}\n`;
   }
 
   /**

--- a/scripts/run-nomiclabs.sh
+++ b/scripts/run-nomiclabs.sh
@@ -30,25 +30,6 @@ echo "PR_PATH >>>>> $PR_PATH"
 
 echo ""
 echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
-echo "Simple buidler/buidler-trufflev5    "
-echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
-echo ""
-
-# Install buidler-e2e
-git clone https://github.com/sc-forks/buidler-e2e.git
-cd buidler-e2e
-npm install --silent
-
-# Install and run solidity-coverage @ PR
-npm install --save-dev --silent $PR_PATH
-cat package.json
-
-npx buidler coverage
-
-verifyCoverageExists
-
-echo ""
-echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
 echo "Simple hardhat/hardhat-trufflev5    "
 echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
 echo ""

--- a/test/units/assert.js
+++ b/test/units/assert.js
@@ -26,14 +26,14 @@ describe('asserts and requires', () => {
     const mapping = coverage.generate(contract.data, util.pathPrefix);
 
     assert.deepEqual(mapping[util.filePath].l, {
-      5: 1,
+      5: 2,
     });
     assert.deepEqual(mapping[util.filePath].b, {});
     assert.deepEqual(mapping[util.filePath].s, {
-      1: 1,
+      1: 2,
     });
     assert.deepEqual(mapping[util.filePath].f, {
-      1: 1,
+      1: 2,
     });
   });
 
@@ -47,14 +47,14 @@ describe('asserts and requires', () => {
 
     const mapping = coverage.generate(contract.data, util.pathPrefix);
     assert.deepEqual(mapping[util.filePath].l, {
-      5: 2,
+      5: 4,
     });
     assert.deepEqual(mapping[util.filePath].b, {});
     assert.deepEqual(mapping[util.filePath].s, {
-      1: 2,
+      1: 4,
     });
     assert.deepEqual(mapping[util.filePath].f, {
-      1: 2,
+      1: 4,
     });
   });
 

--- a/test/units/function.js
+++ b/test/units/function.js
@@ -101,14 +101,14 @@ describe('function declarations', () => {
     const mapping = coverage.generate(contract.data, util.pathPrefix);
 
     assert.deepEqual(mapping[util.filePath].l, {
-      6: 1, 11: 1
+      6: 2, 11: 1 // Doubled line-hit
     });
     assert.deepEqual(mapping[util.filePath].b, {});
     assert.deepEqual(mapping[util.filePath].s, {
-      1: 1, 2: 1
+      1: 2, 2: 1
     });
     assert.deepEqual(mapping[util.filePath].f, {
-      1: 1,
+      1: 2,
       2: 1,
     });
   });


### PR DESCRIPTION
#651, #649 

Excludes contract level instrumentation from the contract's public interface.   

This doubles the line hits for some reason...nbd - we already have this problem on the beta with the boolean hash methods.