### PR TITLE
Add test fixture for solc-8

### DIFF
--- a/test/integration/projects/solc-8/.solcover.js
+++ b/test/integration/projects/solc-8/.solcover.js
@@ -1,0 +1,6 @@
+module.exports = {
+  silent: process.env.SILENT ? true : false,
+  skipFiles: ['skipped-folder'],
+  istanbulReporter: ['json-summary', 'text'],
+  configureYulOptimizer: true
+}

--- a/test/integration/projects/solc-8/contracts/Contract_solc8.sol
+++ b/test/integration/projects/solc-8/contracts/Contract_solc8.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.0 <0.9.0;
+pragma abicoder v2;
+
+error InvalidSomeAddress(address someAddress);
+
+contract ContractA {
+
+    address public someAddress;
+
+    function throwError(address _add) external {
+        this;
+
+        if (_add == address(0)) {
+          revert InvalidSomeAddress(_add);
+        }
+
+        someAddress = _add;
+    }
+}

--- a/test/integration/projects/solc-8/hardhat.config.js
+++ b/test/integration/projects/solc-8/hardhat.config.js
@@ -1,0 +1,9 @@
+require("@nomiclabs/hardhat-truffle5");
+require(__dirname + "/../plugins/nomiclabs.plugin");
+
+module.exports = {
+  solidity: {
+    version: "0.8.5"
+  },
+  logger: process.env.SILENT ? { log: () => {} } : console,
+};

--- a/test/integration/projects/solc-8/test/test_solc8.js
+++ b/test/integration/projects/solc-8/test/test_solc8.js
@@ -1,0 +1,13 @@
+const ContractA = artifacts.require("ContractA");
+
+contract("contracta", function(accounts) {
+  let a,b;
+
+  before(async () => {
+    a = await ContractA.new();
+  })
+
+  it('a:throwError', async function(){
+    await a.throwError(a.address);
+  });
+});

--- a/test/units/hardhat/standard.js
+++ b/test/units/hardhat/standard.js
@@ -326,6 +326,22 @@ describe('Hardhat Plugin: standard use cases', function() {
     verify.lineCoverage(expected);
   })
 
+  it('solc 0.8.x', async function(){
+    mock.installFullProject('solc-8');
+    mock.hardhatSetupEnv(this);
+
+    await this.env.run("coverage");
+
+    const expectedLine = [
+      {
+        file: mock.pathToContract(hardhatConfig, 'Contract_solc8.sol'),
+        pct: 75
+      },
+    ];
+
+    verify.lineCoverage(expectedLine);
+  });
+
   // This test freezes when gas-reporter is not disabled
   it('disables hardhat-gas-reporter', async function() {
     mock.installFullProject('hardhat-gas-reporter');


### PR DESCRIPTION
#657 

Note: while line and branch coverage are correct for the new Error syntax, `revert` on it's own is not covered as a statement. Ignoring for now because statement tracking isn't supported by any of the coverage CI services. 