### PR TITLE
Fixes for beta release

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -31,16 +31,14 @@ parse.BinaryOperation = function(contract, expression, skipStatementRegistry) {
   // Free-floating ternary conditional
   if (expression.left && expression.left.type === 'Conditional'){
     parse[expression.left.type](contract, expression.left, true);
-    register.statement(contract, expression);
 
   // Ternary conditional assignment
   } else if (expression.right && expression.right.type === 'Conditional'){
     parse[expression.right.type](contract, expression.right, true);
-    register.statement(contract, expression);
 
   // Regular binary operation
   } else if(!skipStatementRegistry){
-    register.statement(contract, expression);
+    // noop
 
   // LogicalOR condition search...
   } else {
@@ -89,7 +87,7 @@ parse.FunctionCall = function(contract, expression, skipStatementRegistry) {
 
 parse.Conditional = function(contract, expression, skipStatementRegistry) {
   parse[expression.condition.type] &&
-  parse[expression.condition.type](contract, expression.condition, skipStatementRegistry);
+  parse[expression.condition.type](contract, expression.condition, true);
 
   register.conditional(contract, expression);
 };

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "license": "ISC",
   "dependencies": {
     "@ethersproject/abi": "^5.0.9",
-    "@solidity-parser/parser": "^0.11.0",
+    "@solidity-parser/parser": "^0.14.1",
     "@truffle/provider": "^0.2.24",
     "chalk": "^2.4.2",
     "death": "^1.1.0",

--- a/plugins/hardhat.plugin.js
+++ b/plugins/hardhat.plugin.js
@@ -106,7 +106,7 @@ task("coverage", "Generates a code coverage report for tests")
     api = new API(utils.loadSolcoverJS(config));
 
     // Catch interrupt signals
-    process.on("SIGINT", nomiclabsUtils.finish.bind(null, config, api));
+    process.on("SIGINT", nomiclabsUtils.finish.bind(null, config, api, true));
 
     // Version Info
     ui.report('hardhat-versions', [pkg.version]);

--- a/plugins/resources/nomiclabs.utils.js
+++ b/plugins/resources/nomiclabs.utils.js
@@ -128,6 +128,7 @@ function configureHardhatEVMGas(networkConfig, api){
   networkConfig.blockGasLimit = api.gasLimitNumber;
   networkConfig.gas =  api.gasLimit;
   networkConfig.gasPrice = api.gasPrice;
+  networkConfig.initialBaseFeePerGas = 0;
 }
 
 function configureNetworkEnv(env, networkName, networkConfig, provider, isHardhatEVM){

--- a/plugins/resources/nomiclabs.utils.js
+++ b/plugins/resources/nomiclabs.utils.js
@@ -239,7 +239,7 @@ function tempCacheDir(config){
  * @param  {SolidityCoverage}  api
  * @return {Promise}
  */
-async function finish(config, api){
+async function finish(config, api, shouldKill){
   const {
     tempContractsDir,
     tempArtifactsDir
@@ -252,6 +252,7 @@ async function finish(config, api){
   shell.config.silent = false;
 
   if (api) await api.finish();
+  if (shouldKill) process.exit(1)
 }
 
 module.exports = {

--- a/test/units/conditional.js
+++ b/test/units/conditional.js
@@ -5,7 +5,7 @@ const client = require('ganache-cli');
 const Coverage = require('./../../lib/coverage');
 const Api = require('./../../lib/api')
 
-describe.only('ternary conditionals', () => {
+describe('ternary conditionals', () => {
   let coverage;
   let api;
 

--- a/test/units/conditional.js
+++ b/test/units/conditional.js
@@ -5,7 +5,7 @@ const client = require('ganache-cli');
 const Coverage = require('./../../lib/coverage');
 const Api = require('./../../lib/api')
 
-describe('ternary conditionals', () => {
+describe.only('ternary conditionals', () => {
   let coverage;
   let api;
 
@@ -33,7 +33,7 @@ describe('ternary conditionals', () => {
       1: [1, 0],
     });
     assert.deepEqual(mapping[util.filePath].s, {
-      1: 1, 2: 1, 3: 1,
+      1: 1, 2: 1,
     });
     assert.deepEqual(mapping[util.filePath].f, {
       1: 1,
@@ -50,7 +50,7 @@ describe('ternary conditionals', () => {
       1: [1, 0],
     });
     assert.deepEqual(mapping[util.filePath].s, {
-      1: 1, 2: 1, 3: 1,
+      1: 1, 2: 1,
     });
     assert.deepEqual(mapping[util.filePath].f, {
       1: 1,
@@ -67,7 +67,7 @@ describe('ternary conditionals', () => {
       1: [1, 0],
     });
     assert.deepEqual(mapping[util.filePath].s, {
-      1: 1, 2: 1, 3: 1,
+      1: 1, 2: 1,
     });
     assert.deepEqual(mapping[util.filePath].f, {
       1: 1,
@@ -84,7 +84,7 @@ describe('ternary conditionals', () => {
       1: [0, 1], 2: [1, 0],
     });
     assert.deepEqual(mapping[util.filePath].s, {
-      1: 1, 2: 1, 3: 1,
+      1: 1, 2: 1,
     });
     assert.deepEqual(mapping[util.filePath].f, {
       1: 1,
@@ -101,7 +101,7 @@ describe('ternary conditionals', () => {
       1: [0, 1], 2: [1, 0],
     });
     assert.deepEqual(mapping[util.filePath].s, {
-      1: 1, 2: 1, 3: 1,
+      1: 1, 2: 1,
     });
     assert.deepEqual(mapping[util.filePath].f, {
       1: 1,
@@ -118,7 +118,7 @@ describe('ternary conditionals', () => {
       1: [0, 0], 2: [0, 1],
     });
     assert.deepEqual(mapping[util.filePath].s, {
-      1: 1, 2: 1, 3: 1,
+      1: 1, 2: 1,
     });
     assert.deepEqual(mapping[util.filePath].f, {
       1: 1,
@@ -135,7 +135,7 @@ describe('ternary conditionals', () => {
       1: [0, 1],
     });
     assert.deepEqual(mapping[util.filePath].s, {
-      1: 1, 2: 1, 3: 1,
+      1: 1, 2: 1,
     });
     assert.deepEqual(mapping[util.filePath].f, {
       1: 1,
@@ -152,7 +152,7 @@ describe('ternary conditionals', () => {
       1: [1, 0],
     });
     assert.deepEqual(mapping[util.filePath].s, {
-      1: 1, 2: 1, 3: 1,
+      1: 1, 2: 1,
     });
     assert.deepEqual(mapping[util.filePath].f, {
       1: 1,
@@ -169,7 +169,7 @@ describe('ternary conditionals', () => {
       1: [0, 1],
     });
     assert.deepEqual(mapping[util.filePath].s, {
-      1: 1, 2: 1, 3: 1,
+      1: 1, 2: 1,
     });
     assert.deepEqual(mapping[util.filePath].f, {
       1: 1,
@@ -205,7 +205,7 @@ describe('ternary conditionals', () => {
       1: [0, 1],
     });
     assert.deepEqual(mapping[util.filePath].s, {
-      1: 1, 2: 1, 3: 1, 4: 1,
+      1: 1, 2: 1, 3: 1,
     });
     assert.deepEqual(mapping[util.filePath].f, {
       1: 1,
@@ -222,7 +222,7 @@ describe('ternary conditionals', () => {
       1: [0, 1],
     });
     assert.deepEqual(mapping[util.filePath].s, {
-      1: 1, 2: 1,
+      1: 1,
     });
     assert.deepEqual(mapping[util.filePath].f, {
       1: 1,

--- a/test/units/function.js
+++ b/test/units/function.js
@@ -107,7 +107,7 @@ describe('function declarations', () => {
     });
     assert.deepEqual(mapping[util.filePath].b, {});
     assert.deepEqual(mapping[util.filePath].s, {
-      1: 1, 2: 1
+      1: 1,
     });
     assert.deepEqual(mapping[util.filePath].f, {
       1: 1,

--- a/test/units/if.js
+++ b/test/units/if.js
@@ -39,7 +39,7 @@ describe('if, else, and else if statements', () => {
       1: [1, 0],
     });
     assert.deepEqual(mapping[util.filePath].s, {
-      1: 1, 2: 1,
+      1: 1,
     });
     assert.deepEqual(mapping[util.filePath].f, {
       1: 1,
@@ -60,7 +60,7 @@ describe('if, else, and else if statements', () => {
       1: [1, 0],
     });
     assert.deepEqual(mapping[util.filePath].s, {
-      1: 1, 2: 1,
+      1: 1,
     });
     assert.deepEqual(mapping[util.filePath].f, {
       1: 1,
@@ -82,7 +82,7 @@ describe('if, else, and else if statements', () => {
       1: [1, 0],
     });
     assert.deepEqual(mapping[util.filePath].s, {
-      1: 1, 2: 1,
+      1: 1,
     });
     assert.deepEqual(mapping[util.filePath].f, {
       1: 1,
@@ -105,7 +105,7 @@ describe('if, else, and else if statements', () => {
       1: [1, 0],
     });
     assert.deepEqual(mapping[util.filePath].s, {
-      1: 1, 2: 1,
+      1: 1,
     });
     assert.deepEqual(mapping[util.filePath].f, {
       1: 1,
@@ -127,7 +127,7 @@ describe('if, else, and else if statements', () => {
       1: [0, 1],
     });
     assert.deepEqual(mapping[util.filePath].s, {
-      1: 1, 2: 0,
+      1: 1,
     });
     assert.deepEqual(mapping[util.filePath].f, {
       1: 1,
@@ -149,7 +149,7 @@ describe('if, else, and else if statements', () => {
       1: [0, 1],
     });
     assert.deepEqual(mapping[util.filePath].s, {
-      1: 1, 2: 0, 3: 1,
+      1: 1, 2: 0,
     });
     assert.deepEqual(mapping[util.filePath].f, {
       1: 1,
@@ -170,7 +170,7 @@ describe('if, else, and else if statements', () => {
       1: [0, 1],
     });
     assert.deepEqual(mapping[util.filePath].s, {
-      1: 1, 2: 0, 3: 1,
+      1: 1, 2: 0,
     });
     assert.deepEqual(mapping[util.filePath].f, {
       1: 1,
@@ -192,7 +192,7 @@ describe('if, else, and else if statements', () => {
       1: [0, 1], 2: [0, 1]
     });
     assert.deepEqual(mapping[util.filePath].s, {
-      1: 1, 2: 0, 3: 1, 4: 0
+      1: 1, 2: 0, 3: 1,
     });
     assert.deepEqual(mapping[util.filePath].f, {
       1: 1,
@@ -235,7 +235,7 @@ describe('if, else, and else if statements', () => {
       1: [0, 1], 2: [1, 0], 3: [0, 1], 4: [1, 0]
     });
     assert.deepEqual(mapping[util.filePath].s, {
-      1: 1, 2: 0, 3: 1, 4: 1, 5: 0, 6: 1, 7: 0, 8: 1, 9: 1, 10: 0,
+      1: 1, 2: 1, 3: 1, 4: 1,
     });
     assert.deepEqual(mapping[util.filePath].f, {
       1: 1,

--- a/test/units/loops.js
+++ b/test/units/loops.js
@@ -66,7 +66,7 @@ describe('for and while statements', () => {
     });
     assert.deepEqual(mapping[util.filePath].b, {});
     assert.deepEqual(mapping[util.filePath].s, {
-      1: 1, 2: 1, 3: 1,
+      1: 1, 2: 1,
     });
     assert.deepEqual(mapping[util.filePath].f, {
       1: 1,
@@ -85,7 +85,7 @@ describe('for and while statements', () => {
     });
     assert.deepEqual(mapping[util.filePath].b, {});
     assert.deepEqual(mapping[util.filePath].s, {
-      1: 1, 2: 1, 3: 1,
+      1: 1, 2: 1,
     });
     assert.deepEqual(mapping[util.filePath].f, {
       1: 1,

--- a/test/units/modifiers.js
+++ b/test/units/modifiers.js
@@ -159,7 +159,7 @@ describe('modifiers', () => {
       1: [1, 2], 2: [1, 2],
     });
     assert.deepEqual(mapping[util.filePath].s, {
-      1: 3, 2: 1, 3: 1,
+      1: 3, 2: 1,
     });
     assert.deepEqual(mapping[util.filePath].f, {
       1: 3, 2: 1, 3: 1
@@ -187,7 +187,7 @@ describe('modifiers', () => {
       "1":[3,0],"2":[1,2],"3":[3,0],"4":[1,2]
     });
     assert.deepEqual(mapping[util.filePath].s, {
-      "1":3,"2":3,"3":1,"4":1
+      "1":3,"2":3,"3":1,
     });
     assert.deepEqual(mapping[util.filePath].f, {
       "1":3,"2":3,"3":1,"4":1

--- a/test/units/options.js
+++ b/test/units/options.js
@@ -59,7 +59,7 @@ describe('measureCoverage options', () => {
     });
     assert.deepEqual(mapping[util.filePath].b, {});
     assert.deepEqual(mapping[util.filePath].s, {
-      1: 1, 2: 1,
+      1: 1,
     });
     assert.deepEqual(mapping[util.filePath].f, {
       1: 1,
@@ -76,7 +76,7 @@ describe('measureCoverage options', () => {
     assert.deepEqual(mapping[util.filePath].b, {});
 
     assert.deepEqual(mapping[util.filePath].s, {
-      1: 1, 2: 1, 3: 1,
+      1: 1, 2: 1,
     });
     assert.deepEqual(mapping[util.filePath].f, {
       1: 1,

--- a/test/units/statements.js
+++ b/test/units/statements.js
@@ -112,7 +112,7 @@ describe('generic statements', () => {
       1: [0, 1],
     });
     assert.deepEqual(mapping[util.filePath].s, {
-      1: 1, 2: 0, 3: 1,
+      1: 1,
     });
     assert.deepEqual(mapping[util.filePath].f, {
       1: 1,
@@ -130,7 +130,7 @@ describe('generic statements', () => {
     });
     assert.deepEqual(mapping[util.filePath].b, {});
     assert.deepEqual(mapping[util.filePath].s, {
-      1: 1, 2: 1, 3: 1,
+      1: 1, 2: 1,
     });
     assert.deepEqual(mapping[util.filePath].f, {
       1: 1, 2: 1,
@@ -148,7 +148,7 @@ describe('generic statements', () => {
     });
     assert.deepEqual(mapping[util.filePath].b, {});
     assert.deepEqual(mapping[util.filePath].s, {
-      1: 1, 2: 1, 3: 1,
+      1: 1, 2: 1,
     });
     assert.deepEqual(mapping[util.filePath].f, {
       1: 1, 2: 1,

--- a/yarn.lock
+++ b/yarn.lock
@@ -609,10 +609,12 @@
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"
 
-"@solidity-parser/parser@^0.11.0":
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/@solidity-parser/parser/-/parser-0.11.0.tgz#28bc1972e1620f7b388b485bca76a78ac2cb5c59"
-  integrity sha512-IaC4IaW8uoOB8lmEkw6c19y1vJBK/+7SzAbGQ+LmBYRPXSLNB+UgpORvmcAJEXhB04kWKyz/Os1U8onqm6U/+w==
+"@solidity-parser/parser@^0.14.1":
+  version "0.14.1"
+  resolved "https://registry.yarnpkg.com/@solidity-parser/parser/-/parser-0.14.1.tgz#179afb29f4e295a77cc141151f26b3848abc3c46"
+  integrity sha512-eLjj2L6AuQjBB6s/ibwCAc0DwrR5Ge+ys+wgWo+bviU7fV2nTMQhU63CGaDKXg9iTmMxwhkyoggdIR7ZGRfMgw==
+  dependencies:
+    antlr4ts "^0.5.0-alpha.4"
 
 "@solidity-parser/parser@^0.5.2":
   version "0.5.2"
@@ -1007,6 +1009,11 @@ ansi-styles@^4.1.0:
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.3.0.tgz#edd803628ae71c04c85ae7a0906edad34b648937"
   dependencies:
     color-convert "^2.0.1"
+
+antlr4ts@^0.5.0-alpha.4:
+  version "0.5.0-alpha.4"
+  resolved "https://registry.yarnpkg.com/antlr4ts/-/antlr4ts-0.5.0-alpha.4.tgz#71702865a87478ed0b40c0709f422cf14d51652a"
+  integrity sha512-WPQDt1B74OfPv/IMS2ekXAKkTZIHl88uMetg6q3OTqgFxZ/dxDXI0EWLyZid/1Pe6hTftyg5N7gel5wNAGxXyQ==
 
 any-promise@1.3.0:
   version "1.3.0"
@@ -7141,6 +7148,7 @@ websocket@^1.0.31:
   dependencies:
     debug "^2.2.0"
     es5-ext "^0.10.50"
+    gulp "^4.0.2"
     nan "^2.14.0"
     typedarray-to-buffer "^3.1.5"
     yaeti "^0.0.6"


### PR DESCRIPTION
+ Update solidity-parser/parser to 0.14.x
+ Fix ignored SIGINT in hardhat plugin
+ Configure network correctly for London HF
+ Stop tracking statement coverage for conditionals

It looks like solc 0.8.x is much stricter about what kinds of statements we're allowed to inject into conditional expressions and we can no longer track statement coverage there. 

This doesn't really matter - coveralls only displays line coverage and the branch coverage injections are unaffected. 