### PR TITLE
Add hardhat to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,5 +60,8 @@
     "hardhat-gas-reporter": "^1.0.1",
     "nyc": "^14.1.1",
     "solc": "^0.7.5"
+  },
+  "peerDependencies": {
+    "hardhat": "^2.9.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -62,6 +62,6 @@
     "solc": "^0.7.5"
   },
   "peerDependencies": {
-    "hardhat": "^2.9.3"
+    "hardhat": "^2.11.0"
   }
 }


### PR DESCRIPTION
This fixes a compatibility issue with Yarn strict pnpMode, as solidity-coverage calls `require()` on hardhat.