### PR TITLE
Update `mocha` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "globby": "^10.0.1",
     "jsonschema": "^1.2.4",
     "lodash": "^4.17.15",
-    "mocha": "7.1.2",
+    "mocha": "10.0.0",
     "node-emoji": "^1.10.0",
     "pify": "^4.0.1",
     "recursive-readdir": "^2.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5948,38 +5948,10 @@ mnemonist@^0.38.0:
   dependencies:
     obliterator "^2.0.0"
 
-mocha@7.1.2:
-  version "7.1.2"
-  resolved "https://registry.yarnpkg.com/mocha/-/mocha-7.1.2.tgz#8e40d198acf91a52ace122cd7599c9ab857b29e6"
-  dependencies:
-    ansi-colors "3.2.3"
-    browser-stdout "1.3.1"
-    chokidar "3.3.0"
-    debug "3.2.6"
-    diff "3.5.0"
-    escape-string-regexp "1.0.5"
-    find-up "3.0.0"
-    glob "7.1.3"
-    growl "1.10.5"
-    he "1.2.0"
-    js-yaml "3.13.1"
-    log-symbols "3.0.0"
-    minimatch "3.0.4"
-    mkdirp "0.5.5"
-    ms "2.1.1"
-    node-environment-flags "1.0.6"
-    object.assign "4.1.0"
-    strip-json-comments "2.0.1"
-    supports-color "6.0.0"
-    which "1.3.1"
-    wide-align "1.1.3"
-    yargs "13.3.2"
-    yargs-parser "13.1.2"
-    yargs-unparser "1.6.0"
-
-mocha@^10.0.0:
+mocha@10.0.0, mocha@^10.0.0:
   version "10.0.0"
   resolved "https://registry.yarnpkg.com/mocha/-/mocha-10.0.0.tgz#205447d8993ec755335c4b13deba3d3a13c4def9"
+  integrity sha512-0Wl+elVUD43Y0BqPZBzZt8Tnkw9CMUdNYnUsTfOM1vuhJVZL+kiesFYsqwBkEEuEixaiPe5ZQdqDgX2jddhmoA==
   dependencies:
     "@ungap/promise-all-settled" "1.1.2"
     ansi-colors "4.1.1"


### PR DESCRIPTION
This fixes the deprecated `fsevents` transitive dependency.

When I do an `npm install` in my own project, I get:
```
npm WARN deprecated fsevents@2.1.3: "Please update to latest v2.3 or v2.2"
```

And further investigating with `npm ls fsevents`:
```
│ └─┬ solidity-coverage@0.8.2
│   └─┬ mocha@7.1.2
│     └─┬ chokidar@3.3.0
│       └── fsevents@2.1.3
```

After bumping mocha to the latest, I see that chokidar is also 3.5.3 and it has fsevents@2.3.2, so all good.

Thanks for maintaining this great coverage tool!