### PR TITLE
Add dependabot config

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,18 @@
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+---
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    open-pull-requests-limit: 5
+    schedule:
+      interval: daily
+      time: "9:00"
+      timezone: MST
+    commit-message:
+      prefix: build
+      include: scope
+    assignees:
+      - cgewecke
+    labels:
+      - build


### PR DESCRIPTION
For semi-automated dependency updates, yay!

In vein of #758, these little-used dependencies might stray out of date easily. Luckily, github offers dependency update spam service, if you're willing to consider/accept it ;)