### PR TITLE
fix: fix missing parameter for Ganache

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -182,7 +182,7 @@ class API {
       return this.server;
     }
 
-    await pify(this.server.listen)(this.port);
+    await pify(this.server.listen)(this.port, this.host);
     const address = `http://${this.host}:${this.port}`;
     this.ui.report('server', [address]);
     return address;


### PR DESCRIPTION
When we specify `url=http://127.0.0.1:8545` we expect Ganache to use ipv4.

However, with node >=18, Ganache would only listen to ipv6.

This fixes the problem. 