### PR TITLE
Add a package description

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "solidity-coverage",
   "version": "0.8.1",
-  "description": "",
+  "description": "Code coverage for Solidity testing",
   "main": "plugins/nomiclabs.plugin.js",
   "bin": {
     "solidity-coverage": "./plugins/bin.js"


### PR DESCRIPTION
This description is shown e.g. when hovering with the cursor over the package name in VSCode.

This is what VSCode currently shows:

<img width="519" alt="Screenshot 2022-12-24 at 13 35 34" src="https://user-images.githubusercontent.com/106395723/209436515-36a0be19-1dcf-4b50-9953-2f16e52faf3b.png">

This is how it should look like:

<img width="519" alt="Screenshot 2022-12-24 at 13 37 56" src="https://user-images.githubusercontent.com/106395723/209436559-5f1789d7-bf47-4a66-af36-daa5760e7c94.png">