### PR TITLE
Prepare for next hardhat version

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -279,9 +279,16 @@ class API {
   }
 
   // Hardhat
-  attachToHardhatVM(provider){
+  async attachToHardhatVM(provider){
     const self = this;
     this.collector = new DataCollector(this.instrumenter.instrumentationData);
+
+    if ('init' in provider) {
+      // Newer versions of Hardhat initialize the provider lazily, so we need to
+      // call provider.init() explicitly. This is a no-op if the provider is
+      // already initialized.
+      await provider.init();
+    }
 
     let cur = provider;
 

--- a/plugins/hardhat.plugin.js
+++ b/plugins/hardhat.plugin.js
@@ -198,7 +198,7 @@ task("coverage", "Generates a code coverage report for tests")
     // ==============
     // Server launch
     // ==============
-    let network = nomiclabsUtils.setupHardhatNetwork(env, api, ui);
+    let network = await nomiclabsUtils.setupHardhatNetwork(env, api, ui);
 
     if (network.isHardhatEVM){
       accounts = await utils.getAccountsHardhat(network.provider);
@@ -206,11 +206,11 @@ task("coverage", "Generates a code coverage report for tests")
 
       // Note: this only works if the reset block number is before any transactions have fired on the fork.
       // e.g you cannot fork at block 1, send some txs (blocks 2,3,4) and reset to block 2
-      env.network.provider.on(HARDHAT_NETWORK_RESET_EVENT, () => {
-        api.attachToHardhatVM(env.network.provider);
+      env.network.provider.on(HARDHAT_NETWORK_RESET_EVENT, async () => {
+        await api.attachToHardhatVM(env.network.provider);
       });
 
-      api.attachToHardhatVM(network.provider);
+      await api.attachToHardhatVM(network.provider);
 
       ui.report('hardhat-network', [
         nodeInfo.split('/')[1],

--- a/plugins/resources/nomiclabs.utils.js
+++ b/plugins/resources/nomiclabs.utils.js
@@ -75,9 +75,13 @@ function setupBuidlerNetwork(env, api, ui){
   )
 }
 
-function setupHardhatNetwork(env, api, ui){
+async function setupHardhatNetwork(env, api, ui){
+  const hardhatPackage = require('hardhat/package.json');
   const { createProvider } = require("hardhat/internal/core/providers/construction");
   const { HARDHAT_NETWORK_NAME } = require("hardhat/plugins")
+
+  // after 2.15.0, the internal createProvider function has a different signature
+  const newCreateProviderSignature = semver.satisfies(hardhatPackage.version, "^2.15.0");
 
   let provider, networkName, networkConfig;
   let isHardhatEVM = false;
@@ -91,12 +95,20 @@ function setupHardhatNetwork(env, api, ui){
     networkConfig = env.network.config;
     configureHardhatEVMGas(networkConfig, api);
 
-    provider = createProvider(
-      networkName,
-      networkConfig,
-      env.config.paths,
-      env.artifacts,
-    )
+    if (newCreateProviderSignature) {
+      provider = await createProvider(
+        env.config,
+        networkName,
+        env.artifacts,
+      )
+    } else {
+      provider = createProvider(
+        networkName,
+        networkConfig,
+        env.config.paths,
+        env.artifacts,
+      )
+    }
 
   // HttpProvider
   } else {
@@ -106,7 +118,12 @@ function setupHardhatNetwork(env, api, ui){
     networkConfig = env.config.networks[networkName]
     configureNetworkGas(networkConfig, api);
     configureHttpProvider(networkConfig, api, ui)
-    provider = createProvider(networkName, networkConfig);
+
+    if (newCreateProviderSignature) {
+      provider = await createProvider(env.config, networkName);
+    } else {
+      provider = createProvider(networkName, networkConfig);
+    }
   }
 
   return configureNetworkEnv(


### PR DESCRIPTION
`solidity-coverage` relies on a couple of internal APIs that we are about to change:

- The `network.provider` object is now lazily initialized, which means that you have to call `.init()` it before trying to navigate the `_wrapped` provider chain
- The `createProvider` signature changed, and this function is async now

This change means that **solidity-coverage might not work correctly with extended providers**, since we are not passing the extenders to `createProvider`. I don't think this is going to be a problem immediately, but it's something that should be fixed sooner rather than later.