### PR TITLE
Add command option to specify the source files to run the coverage on

### DIFF
--- a/plugins/hardhat.plugin.js
+++ b/plugins/hardhat.plugin.js
@@ -97,6 +97,7 @@ task("coverage", "Generates a code coverage report for tests")
   .addOptionalParam("testfiles",  ui.flags.file,       "", types.string)
   .addOptionalParam("solcoverjs", ui.flags.solcoverjs, "", types.string)
   .addOptionalParam('temp',       ui.flags.temp,       "", types.string)
+  .addOptionalParam('sources',    ui.flags.sources,    "", types.string)
   .addFlag('matrix', ui.flags.testMatrix)
   .addFlag('abi', ui.flags.abi)
   .setAction(async function(args, env){

--- a/plugins/resources/nomiclabs.utils.js
+++ b/plugins/resources/nomiclabs.utils.js
@@ -31,7 +31,7 @@ function getTestFilePaths(files){
  */
 function normalizeConfig(config, args={}){
   config.workingDir = config.paths.root;
-  config.contractsDir = config.paths.sources;
+  config.contractsDir = args.sources? args.sources : config.paths.sources;
   config.testDir = config.paths.tests;
   config.artifactsDir = config.paths.artifacts;
   config.logger = config.logger ? config.logger : {log: null};

--- a/test/integration/projects/test-files/contracts/otherContracts/OtherContractA.sol
+++ b/test/integration/projects/test-files/contracts/otherContracts/OtherContractA.sol
@@ -1,0 +1,17 @@
+pragma solidity ^0.7.0;
+
+
+contract OtherContractA {
+  uint x;
+  constructor() public {
+  }
+
+  function sendFn() public {
+    x = 5;
+  }
+
+  function callFn() public pure returns (uint){
+    uint y = 5;
+    return y;
+  }
+}

--- a/test/integration/projects/test-files/test/other_contract_a.js
+++ b/test/integration/projects/test-files/test/other_contract_a.js
@@ -1,0 +1,15 @@
+const OtherContractA = artifacts.require("OtherContractA");
+
+contract("otherContractA", function(accounts) {
+  let instance;
+
+  before(async () => instance = await OtherContractA.new())
+
+  it('sends', async function(){
+    await instance.sendFn();
+  });
+
+  it('calls', async function(){
+    await instance.callFn();
+  })
+});

--- a/test/units/hardhat/flags.js
+++ b/test/units/hardhat/flags.js
@@ -230,5 +230,33 @@ describe('Hardhat Plugin: command line options', function() {
     const output = require(outputPath);
     assert.deepEqual(output, expected);
   })
+
+  it('--sources contract/<fileName>', async function() {
+
+    const taskArgs = {
+      testfiles: path.join(
+        hardhatConfig.paths.root,
+        'test/other_contract_a.js'
+      ),
+      sources: path.join(
+        hardhatConfig.paths.root,
+        'contracts/otherContracts'
+      )
+    };
+    mock.installFullProject('test-files');
+    mock.hardhatSetupEnv(this);
+
+    await this.env.run("coverage", taskArgs);
+
+    const expected = [
+      {
+        file: mock.pathToContract(hardhatConfig, 'otherContracts/OtherContractA.sol'),
+        pct: 100
+      }
+    ];
+
+    verify.lineCoverage(expected);
+  });
+
 });
 


### PR DESCRIPTION
solves #805 

The solution proposed is to add a `--sources` command option to specify the file source.