### PR TITLE
Perform ternary conditional injections before branch injections (#828)

### DIFF
--- a/lib/instrumenter.js
+++ b/lib/instrumenter.js
@@ -96,8 +96,10 @@ class Instrumenter {
       // Line instrumentation has to happen first
       contract.injectionPoints[injectionPoint].sort((a, b) => {
         const injections = [
-          'injectLogicalOR',
           'injectBranch',
+          'injectOpenParen',
+          'injectOrFalse',
+          'injectAndTrue',
           'injectEmptyBranch',
           'injectLine'
         ];

--- a/test/sources/solidity/contracts/conditional/ternary-with-unbracketed-else.sol
+++ b/test/sources/solidity/contracts/conditional/ternary-with-unbracketed-else.sol
@@ -1,0 +1,8 @@
+pragma solidity ^0.7.0;
+
+contract Test {
+    function a() public {
+        int i = 0;
+        if (false) {} else i == 0 ? i = 0 : i--;
+    }
+}

--- a/test/units/conditional.js
+++ b/test/units/conditional.js
@@ -229,4 +229,8 @@ describe('ternary conditionals', () => {
     });
   });
 
+  it('should compile after instrumenting a ternary conditional which follows an unbracketed else', () => {
+    const info = util.instrumentAndCompile('conditional/ternary-with-unbracketed-else');
+    util.report(info.solcOutput.errors);
+  });
 });


### PR DESCRIPTION
In #821, a ternary conditional is placed directly after an unbracketed `else` statement as below

```solidity
if (false) {} else i == 0 ? i = 0 : i--;
```

Several injections are necessary at the same location here and the order in which they happen matters. Because the branch injection for the `else` occurred first, it was being located inside the ternary clause as below

```solidity
else {
  ((c_8d074f5a(0x65ac343036e60c28); /*else branch */ 
  i == 0 || c_false8d074f5a(0x1ca8ac37326695dd)) && c_true8d074f5a(0x909a47063763861b)) ? i = 0 : i--;}
}
```

This PR explicitly prioritizes branch injections over conditional component injections
