### PR TITLE
Add test for file level `using for` statements

### DIFF
--- a/test/integration/projects/solc-8/contracts/Contract_solc8.sol
+++ b/test/integration/projects/solc-8/contracts/Contract_solc8.sol
@@ -2,10 +2,13 @@
 pragma solidity >=0.8.0 <0.9.0;
 pragma abicoder v2;
 
+import "./Library_solc8.sol";
+
 error InvalidSomeAddress(address someAddress);
 
-contract ContractA {
+using Library_solc8 for uint256;
 
+contract ContractA {
     mapping(bytes32 key => uint256) public authorization;
     address public someAddress;
 

--- a/test/integration/projects/solc-8/contracts/Library_solc8.sol
+++ b/test/integration/projects/solc-8/contracts/Library_solc8.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.0 <0.9.0;
+
+library Library_solc8 {
+    uint constant x = 1;
+    function a() public view returns (uint) {
+        return x;
+    }
+}


### PR DESCRIPTION
#724. This syntax might have been unsupported by `solidity-parser/parser` at some point but it seems to work without problems now. 