### PR TITLE
Fix instrumentation error for virtual modifiers

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -217,9 +217,11 @@ parse.Modifiers = function(contract, modifiers) {
 };
 
 parse.ModifierDefinition = function(contract, expression) {
-  register.functionDeclaration(contract, expression);
-  parse[expression.body.type] &&
-  parse[expression.body.type](contract, expression.body);
+  if (expression.body) {
+    register.functionDeclaration(contract, expression);
+    parse[expression.body.type] &&
+    parse[expression.body.type](contract, expression.body);
+  }
 };
 
 parse.NewExpression = function(contract, expression) {

--- a/test/integration/projects/solc-8/contracts/Abstract_solc8.sol
+++ b/test/integration/projects/solc-8/contracts/Abstract_solc8.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.0 <0.9.0;
+
+abstract contract ContractB {
+    modifier onlyOwner() virtual;
+}


### PR DESCRIPTION
#766 

Updates parsing to check that modifier definitions have a body before instrumenting them (like functions)