### PR TITLE
Add test for modifiers with post-conditions

### DIFF
--- a/test/sources/solidity/contracts/modifiers/postconditions.sol
+++ b/test/sources/solidity/contracts/modifiers/postconditions.sol
@@ -1,0 +1,24 @@
+pragma solidity ^0.7.0;
+
+contract Test {
+    bool precondition = true;
+    bool postcondition = true;
+
+    modifier m {
+      require(precondition);
+      _;
+      require(postcondition);
+    }
+
+    function flip_precondition() public {
+      precondition = !precondition;
+    }
+
+    function flip_postcondition() public {
+      postcondition = !postcondition;
+    }
+
+    function a() m public {
+      uint x = 5;
+    }
+}


### PR DESCRIPTION
Test generated for investigating #761. The modifier instrumentation does not track post-function execution in any modifiers - this test just makes sure there's nothing totally bizarre going on with Solidity's implementation under the hood.