### PR TITLE
Add test for multi-contract files with inheritance

### DIFF
--- a/test/sources/solidity/contracts/statements/multi-contract-diamond.sol
+++ b/test/sources/solidity/contracts/statements/multi-contract-diamond.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.7.0;
+
+contract A {
+    uint valA;
+
+    function setA() public {
+        valA = 1;
+    }
+}
+
+contract B is A {
+    uint valB;
+
+    function setB() public {
+        valB = 1;
+    }
+}
+
+contract C is A {
+    uint valC;
+
+    function setC() public {
+        valC = 1;
+    }
+}
+
+contract D is B, C {
+    uint valD;
+
+    function setD() public {
+        valD = 1;
+    }
+}

--- a/test/units/statements.js
+++ b/test/units/statements.js
@@ -66,6 +66,11 @@ describe('generic statements', () => {
     util.report(info.solcOutput.errors);
   })
 
+  it('should instrument a multi-contract file with diamond inheritance (#769)', () => {
+    const info = util.instrumentAndCompile('statements/multi-contract-diamond');
+    util.report(info.solcOutput.errors);
+  });
+
   it('should NOT pass tests if the contract has a compilation error', () => {
     const info = util.instrumentAndCompile('app/SimpleError');
     try {


### PR DESCRIPTION
Adds a test to investigate #769. A comment there suggested that there's a declaration compilation error when multi-contract files inherit from each other (but it doesn't reproduce.)

