### PR TITLE
Use Hardhat client and ethers in unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "@nomiclabs/hardhat-truffle5": "^2.0.0",
     "@nomiclabs/hardhat-waffle": "^2.0.1",
     "@nomiclabs/hardhat-web3": "^2.0.0",
-    "@truffle/contract": "4.0.36",
     "chai": "^4.3.4",
     "decache": "^4.5.1",
     "ethereum-waffle": "^3.4.0",

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -9,6 +9,7 @@ SILENT=true node --max-old-space-size=4096 \
   -- \
   mocha \
     test/units/* test/integration/* \
+    --require "test/util/mochaRootHook.js" \
     --timeout 100000 \
     --no-warnings \
     --exit \

--- a/scripts/unit.sh
+++ b/scripts/unit.sh
@@ -6,6 +6,7 @@ node --max-old-space-size=4096 \
     --exclude '**/test/**/' \
   -- \
   mocha test/units/* \
+    --require "test/util/mochaRootHook.js" \
     --timeout 100000 \
     --no-warnings \
     --exit

--- a/test/units/conditional.js
+++ b/test/units/conditional.js
@@ -1,7 +1,5 @@
 const assert = require('assert');
 const util = require('./../util/util.js');
-
-const client = require('ganache-cli');
 const Coverage = require('./../../lib/coverage');
 const Api = require('./../../lib/api')
 
@@ -9,22 +7,19 @@ describe('ternary conditionals', () => {
   let coverage;
   let api;
 
-  before(async () => {
-    api = new Api({silent: true});
-    await api.ganache(client);
-  })
+  before(async () => api = new Api({silent: true}));
   beforeEach(() => coverage = new Coverage());
   after(async() => await api.finish());
 
-  async function setupAndRun(solidityFile){
-    const contract = await util.bootstrapCoverage(solidityFile, api);
+  async function setupAndRun(solidityFile, provider){
+    const contract = await util.bootstrapCoverage(solidityFile, api, provider);
     coverage.addContract(contract.instrumented, util.filePath);
-    await contract.instance.a();
+    await contract.instance.a(contract.gas);
     return coverage.generate(contract.data, util.pathPrefix);
   }
 
   it('should cover a conditional that reaches the consequent (same-line)', async function() {
-    const mapping = await setupAndRun('conditional/sameline-consequent');
+    const mapping = await setupAndRun('conditional/sameline-consequent', this.provider);
 
     assert.deepEqual(mapping[util.filePath].l, {
       5: 1, 6: 1, 7: 1,
@@ -41,7 +36,7 @@ describe('ternary conditionals', () => {
   });
 
   it('should cover an unbracketed conditional that reaches the consequent (same-line)', async function() {
-    const mapping = await setupAndRun('conditional/unbracketed-condition');
+    const mapping = await setupAndRun('conditional/unbracketed-condition', this.provider);
 
     assert.deepEqual(mapping[util.filePath].l, {
       5: 1, 6: 1, 7: 1,
@@ -58,7 +53,7 @@ describe('ternary conditionals', () => {
   });
 
   it('should cover a multi-part conditional (&&) that reaches the consequent', async function() {
-    const mapping = await setupAndRun('conditional/and-condition');
+    const mapping = await setupAndRun('conditional/and-condition', this.provider);
 
     assert.deepEqual(mapping[util.filePath].l, {
       5: 1, 6: 1, 7: 1,
@@ -75,7 +70,7 @@ describe('ternary conditionals', () => {
   });
 
   it('should cover a multi-part conditional (||) that reaches the consequent', async function() {
-    const mapping = await setupAndRun('conditional/or-condition');
+    const mapping = await setupAndRun('conditional/or-condition', this.provider);
 
     assert.deepEqual(mapping[util.filePath].l, {
       5: 1, 6: 1, 7: 1,
@@ -92,7 +87,7 @@ describe('ternary conditionals', () => {
   });
 
   it('should cover a multi-part unbracketed conditional (||) that reaches the consequent', async function() {
-    const mapping = await setupAndRun('conditional/unbracketed-or-condition');
+    const mapping = await setupAndRun('conditional/unbracketed-or-condition', this.provider);
 
     assert.deepEqual(mapping[util.filePath].l, {
       5: 1, 6: 1, 7: 1,
@@ -109,7 +104,7 @@ describe('ternary conditionals', () => {
   });
 
   it('should cover an always-false multi-part unbracketed conditional (||)', async function() {
-    const mapping = await setupAndRun('conditional/or-always-false-condition');
+    const mapping = await setupAndRun('conditional/or-always-false-condition', this.provider);
 
     assert.deepEqual(mapping[util.filePath].l, {
       5: 1, 6: 1, 7: 1,
@@ -126,7 +121,7 @@ describe('ternary conditionals', () => {
   });
 
   it('should cover a conditional that reaches the alternate (same-line)', async function() {
-    const mapping = await setupAndRun('conditional/sameline-alternate');
+    const mapping = await setupAndRun('conditional/sameline-alternate', this.provider);
 
     assert.deepEqual(mapping[util.filePath].l, {
       5: 1, 6: 1, 7: 1,
@@ -143,7 +138,7 @@ describe('ternary conditionals', () => {
   });
 
   it('should cover a conditional that reaches the consequent (multi-line)', async function() {
-    const mapping = await setupAndRun('conditional/multiline-consequent');
+    const mapping = await setupAndRun('conditional/multiline-consequent', this.provider);
 
     assert.deepEqual(mapping[util.filePath].l, {
       5: 1, 6: 1, 7: 1,
@@ -160,7 +155,7 @@ describe('ternary conditionals', () => {
   });
 
   it('should cover a conditional that reaches the alternate (multi-line)', async function() {
-    const mapping = await setupAndRun('conditional/multiline-alternate');
+    const mapping = await setupAndRun('conditional/multiline-alternate', this.provider);
 
     assert.deepEqual(mapping[util.filePath].l, {
       5: 1, 6: 1, 7: 1,
@@ -178,7 +173,7 @@ describe('ternary conditionals', () => {
 
   // Runs bool z = (x) ? false : true;
   it('should cover a definition assignment by conditional that reaches the alternate', async function() {
-    const mapping = await setupAndRun('conditional/declarative-exp-assignment-alternate');
+    const mapping = await setupAndRun('conditional/declarative-exp-assignment-alternate', this.provider);
 
     assert.deepEqual(mapping[util.filePath].l, {
       5: 1, 6: 1, 7: 1,
@@ -196,7 +191,7 @@ describe('ternary conditionals', () => {
 
   // Runs z = (x) ? false : true;
   it('should cover an identifier assignment by conditional that reaches the alternate', async function() {
-    const mapping = await setupAndRun('conditional/identifier-assignment-alternate');
+    const mapping = await setupAndRun('conditional/identifier-assignment-alternate', this.provider);
 
     assert.deepEqual(mapping[util.filePath].l, {
       5: 1, 6: 1, 7: 1, 8: 1,
@@ -213,7 +208,7 @@ describe('ternary conditionals', () => {
   });
 
   it('should cover an assignment to a member expression (reaches the alternate)', async function() {
-    const mapping = await setupAndRun('conditional/mapping-assignment');
+    const mapping = await setupAndRun('conditional/mapping-assignment', this.provider);
 
     assert.deepEqual(mapping[util.filePath].l, {
       11: 1, 12: 1,

--- a/test/units/function.js
+++ b/test/units/function.js
@@ -1,7 +1,5 @@
 const assert = require('assert');
 const util = require('./../util/util.js');
-
-const client = require('ganache-cli');
 const Coverage = require('./../../lib/coverage');
 const Api = require('./../../lib/api')
 
@@ -9,10 +7,7 @@ describe('function declarations', () => {
   let coverage;
   let api;
 
-  before(async () => {
-    api = new Api({silent: true});
-    await api.ganache(client);
-  })
+  before(async () => api = new Api({silent: true}));
   beforeEach(() => coverage = new Coverage());
   after(async() => await api.finish());
 
@@ -37,9 +32,9 @@ describe('function declarations', () => {
   });
 
   it('should cover a simple invoked function call', async function() {
-    const contract = await util.bootstrapCoverage('function/function-call', api);
+    const contract = await util.bootstrapCoverage('function/function-call', api, this.provider);
     coverage.addContract(contract.instrumented, util.filePath);
-    await contract.instance.a();
+    await contract.instance.a(contract.gas);
     const mapping = coverage.generate(contract.data, util.pathPrefix);
 
     assert.deepEqual(mapping[util.filePath].l, {
@@ -56,9 +51,9 @@ describe('function declarations', () => {
   });
 
   it('should cover a modifier used on a function', async function() {
-    const contract = await util.bootstrapCoverage('function/modifier', api);
+    const contract = await util.bootstrapCoverage('function/modifier', api, this.provider);
     coverage.addContract(contract.instrumented, util.filePath);
-    await contract.instance.a(0);
+    await contract.instance.a(0, contract.gas);
     const mapping = coverage.generate(contract.data, util.pathPrefix);
 
     assert.deepEqual(mapping[util.filePath].l, {

--- a/test/units/if.js
+++ b/test/units/if.js
@@ -1,7 +1,5 @@
 const assert = require('assert');
 const util = require('./../util/util.js');
-
-const client = require('ganache-cli');
 const Coverage = require('./../../lib/coverage');
 const Api = require('./../../lib/api')
 
@@ -9,10 +7,7 @@ describe('if, else, and else if statements', () => {
   let coverage;
   let api;
 
-  before(async () => {
-    api = new Api({silent: true});
-    await api.ganache(client);
-  })
+  before(async () => api = new Api({silent: true}));
   beforeEach(() => coverage = new Coverage());
   after(async() => await api.finish());
 
@@ -27,9 +22,9 @@ describe('if, else, and else if statements', () => {
   });
 
   it('should cover an if statement with a bracketed consequent', async function() {
-    const contract = await util.bootstrapCoverage('if/if-with-brackets', api);
+    const contract = await util.bootstrapCoverage('if/if-with-brackets', api, this.provider);
     coverage.addContract(contract.instrumented, util.filePath);
-    await contract.instance.a(1);
+    await contract.instance.a(1, contract.gas);
     const mapping = coverage.generate(contract.data, util.pathPrefix);
 
     assert.deepEqual(mapping[util.filePath].l, {
@@ -48,9 +43,9 @@ describe('if, else, and else if statements', () => {
 
   // Runs: a(1) => if (x == 1) x = 2;
   it('should cover an unbracketed if consequent (single line)', async function(){
-    const contract = await util.bootstrapCoverage('if/if-no-brackets', api);
+    const contract = await util.bootstrapCoverage('if/if-no-brackets', api, this.provider);
     coverage.addContract(contract.instrumented, util.filePath);
-    await contract.instance.a(1);
+    await contract.instance.a(1, contract.gas);
     const mapping = coverage.generate(contract.data, util.pathPrefix);
 
     assert.deepEqual(mapping[util.filePath].l, {
@@ -69,10 +64,10 @@ describe('if, else, and else if statements', () => {
 
   // Runs: a(1) => if (x == 1){\n x = 3; }
   it('should cover an if statement with multiline bracketed consequent', async function() {
-    const contract = await util.bootstrapCoverage('if/if-with-brackets-multiline',api);
+    const contract = await util.bootstrapCoverage('if/if-with-brackets-multiline',api, this.provider);
 
     coverage.addContract(contract.instrumented, util.filePath);
-    await contract.instance.a(1);
+    await contract.instance.a(1, contract.gas);
     const mapping = coverage.generate(contract.data, util.pathPrefix);
 
     assert.deepEqual(mapping[util.filePath].l, {
@@ -92,10 +87,10 @@ describe('if, else, and else if statements', () => {
 
   // Runs: a(1) => if (x == 1)\n x = 3;
   it('should cover an unbracketed if consequent (multi-line)', async function() {
-    const contract = await util.bootstrapCoverage('if/if-no-brackets-multiline',api);
+    const contract = await util.bootstrapCoverage('if/if-no-brackets-multiline',api, this.provider);
 
     coverage.addContract(contract.instrumented, util.filePath);
-    await contract.instance.a(1);
+    await contract.instance.a(1, contract.gas);
     const mapping = coverage.generate(contract.data, util.pathPrefix);
 
     assert.deepEqual(mapping[util.filePath].l, {
@@ -114,10 +109,10 @@ describe('if, else, and else if statements', () => {
 
   // Runs: a(2) => if (x == 1) { x = 3; }
   it('should cover a simple if statement with a failing condition', async function() {
-    const contract = await util.bootstrapCoverage('if/if-with-brackets',api);
+    const contract = await util.bootstrapCoverage('if/if-with-brackets',api, this.provider);
 
     coverage.addContract(contract.instrumented, util.filePath);
-    await contract.instance.a(2);
+    await contract.instance.a(2, contract.gas);
     const mapping = coverage.generate(contract.data, util.pathPrefix);
 
     assert.deepEqual(mapping[util.filePath].l, {
@@ -136,10 +131,10 @@ describe('if, else, and else if statements', () => {
 
   // Runs: a(2) => if (x == 1){\n throw;\n }else{\n x = 5; \n}
   it('should cover an if statement with a bracketed alternate', async function() {
-    const contract = await util.bootstrapCoverage('if/else-with-brackets',api);
+    const contract = await util.bootstrapCoverage('if/else-with-brackets',api, this.provider);
 
     coverage.addContract(contract.instrumented, util.filePath);
-    await contract.instance.a(2);
+    await contract.instance.a(2, contract.gas);
     const mapping = coverage.generate(contract.data, util.pathPrefix);
 
     assert.deepEqual(mapping[util.filePath].l, {
@@ -157,10 +152,10 @@ describe('if, else, and else if statements', () => {
   });
 
   it('should cover an if statement with an unbracketed alternate', async function() {
-    const contract = await util.bootstrapCoverage('if/else-without-brackets',api);
+    const contract = await util.bootstrapCoverage('if/else-without-brackets',api, this.provider);
 
     coverage.addContract(contract.instrumented, util.filePath);
-    await contract.instance.a(2);
+    await contract.instance.a(2, contract.gas);
     const mapping = coverage.generate(contract.data, util.pathPrefix);
 
     assert.deepEqual(mapping[util.filePath].l, {
@@ -179,10 +174,10 @@ describe('if, else, and else if statements', () => {
   });
 
   it('should cover an else if statement with an unbracketed alternate', async function() {
-    const contract = await util.bootstrapCoverage('if/else-if-without-brackets',api);
+    const contract = await util.bootstrapCoverage('if/else-if-without-brackets',api, this.provider);
 
     coverage.addContract(contract.instrumented, util.filePath);
-    await contract.instance.a(2);
+    await contract.instance.a(2, contract.gas);
     const mapping = coverage.generate(contract.data, util.pathPrefix);
 
     assert.deepEqual(mapping[util.filePath].l, {
@@ -200,10 +195,10 @@ describe('if, else, and else if statements', () => {
   });
 
   it('should cover nested if statements with missing else statements', async function() {
-    const contract = await util.bootstrapCoverage('if/nested-if-missing-else',api);
+    const contract = await util.bootstrapCoverage('if/nested-if-missing-else',api, this.provider);
 
     coverage.addContract(contract.instrumented, util.filePath);
-    await contract.instance.a(2,3,3);
+    await contract.instance.a(2,3,3, contract.gas);
     const mapping = coverage.generate(contract.data, util.pathPrefix);
 
     assert.deepEqual(mapping[util.filePath].l, {
@@ -218,14 +213,13 @@ describe('if, else, and else if statements', () => {
     assert.deepEqual(mapping[util.filePath].f, {
       1: 1,
     });
-
   });
 
   it('should cover if-elseif-else statements that are at the same depth as each other', async function() {
-    const contract = await util.bootstrapCoverage('if/if-elseif-else',api);
+    const contract = await util.bootstrapCoverage('if/if-elseif-else',api, this.provider);
 
     coverage.addContract(contract.instrumented, util.filePath);
-    await contract.instance.a(2,3,3);
+    await contract.instance.a(2,3,3, contract.gas);
     const mapping = coverage.generate(contract.data, util.pathPrefix);
 
     assert.deepEqual(mapping[util.filePath].l, {

--- a/test/units/loops.js
+++ b/test/units/loops.js
@@ -1,7 +1,5 @@
 const assert = require('assert');
 const util = require('./../util/util.js');
-
-const client = require('ganache-cli');
 const Coverage = require('./../../lib/coverage');
 const Api = require('./../../lib/api')
 
@@ -9,18 +7,15 @@ describe('for and while statements', () => {
   let coverage;
   let api;
 
-  before(async () => {
-    api = new Api({silent: true});
-    await api.ganache(client);
-  })
+  before(async () => api = new Api({silent: true}));
   beforeEach(() => coverage = new Coverage());
   after(async() => await api.finish());
 
   // Runs: a() => for(var x = 1; x < 10; x++){\n sha3(x);\n }
   it('should cover a for statement with a bracketed body (multiline)', async function() {
-    const contract = await util.bootstrapCoverage('loops/for-with-brackets', api);
+    const contract = await util.bootstrapCoverage('loops/for-with-brackets', api, this.provider);
     coverage.addContract(contract.instrumented, util.filePath);
-    await contract.instance.a();
+    await contract.instance.a(contract.gas);
     const mapping = coverage.generate(contract.data, util.pathPrefix);
 
     assert.deepEqual(mapping[util.filePath].l, {
@@ -37,9 +32,9 @@ describe('for and while statements', () => {
 
   // Runs: a() => for(var x = 1; x < 10; x++)\n sha3(x);\n
   it('should cover a for statement with an unbracketed body', async function() {
-    const contract = await util.bootstrapCoverage('loops/for-no-brackets', api);
+    const contract = await util.bootstrapCoverage('loops/for-no-brackets', api, this.provider);
     coverage.addContract(contract.instrumented, util.filePath);
-    await contract.instance.a();
+    await contract.instance.a(contract.gas);
     const mapping = coverage.generate(contract.data, util.pathPrefix);
 
     assert.deepEqual(mapping[util.filePath].l, {
@@ -56,9 +51,9 @@ describe('for and while statements', () => {
 
   // Runs: a() => var t = true;\n while(t){\n t = false;\n }
   it('should cover a while statement with an bracketed body (multiline)', async function() {
-    const contract = await util.bootstrapCoverage('loops/while-with-brackets', api);
+    const contract = await util.bootstrapCoverage('loops/while-with-brackets', api, this.provider);
     coverage.addContract(contract.instrumented, util.filePath);
-    await contract.instance.a();
+    await contract.instance.a(contract.gas);
     const mapping = coverage.generate(contract.data, util.pathPrefix);
 
     assert.deepEqual(mapping[util.filePath].l, {
@@ -75,9 +70,9 @@ describe('for and while statements', () => {
 
   // Runs: a() => var t = true;\n while(t)\n t = false;\n
   it('should cover a while statement with an unbracketed body (multiline)', async function() {
-    const contract = await util.bootstrapCoverage('loops/while-no-brackets', api);
+    const contract = await util.bootstrapCoverage('loops/while-no-brackets', api, this.provider);
     coverage.addContract(contract.instrumented, util.filePath);
-    await contract.instance.a();
+    await contract.instance.a(contract.gas);
     const mapping = coverage.generate(contract.data, util.pathPrefix);
 
     assert.deepEqual(mapping[util.filePath].l, {

--- a/test/units/or.js
+++ b/test/units/or.js
@@ -1,7 +1,5 @@
 const assert = require('assert');
 const util = require('./../util/util.js');
-
-const client = require('ganache-cli');
 const Coverage = require('./../../lib/coverage');
 const Api = require('./../../lib/api')
 
@@ -9,18 +7,15 @@ describe('logical OR branches', () => {
   let coverage;
   let api;
 
-  before(async () => {
-    api = new Api({silent: true});
-    await api.ganache(client);
-  })
+  before(async () => api = new Api({silent: true}));
   beforeEach(() => coverage = new Coverage());
   after(async() => await api.finish());
 
   // if (x == 1 || x == 2) { } else ...
   it('should cover an if statement with a simple OR condition (single branch)', async function() {
-    const contract = await util.bootstrapCoverage('or/if-or', api);
+    const contract = await util.bootstrapCoverage('or/if-or', api, this.provider, );
     coverage.addContract(contract.instrumented, util.filePath);
-    await contract.instance.a(1);
+    await contract.instance.a(1, contract.gas);
     const mapping = coverage.generate(contract.data, util.pathPrefix);
 
     assert.deepEqual(mapping[util.filePath].l, {
@@ -39,10 +34,10 @@ describe('logical OR branches', () => {
 
   // if (x == 1 || x == 2) { } else ...
   it('should cover an if statement with a simple OR condition (both branches)', async function() {
-    const contract = await util.bootstrapCoverage('or/if-or', api);
+    const contract = await util.bootstrapCoverage('or/if-or', api, this.provider);
     coverage.addContract(contract.instrumented, util.filePath);
-    await contract.instance.a(1);
-    await contract.instance.a(2);
+    await contract.instance.a(1, contract.gas);
+    await contract.instance.a(2, contract.gas);
 
     const mapping = coverage.generate(contract.data, util.pathPrefix);
 
@@ -62,9 +57,9 @@ describe('logical OR branches', () => {
 
   // require(x == 1 || x == 2)
   it('should cover a require statement with a simple OR condition (single branch)', async function() {
-    const contract = await util.bootstrapCoverage('or/require-or', api);
+    const contract = await util.bootstrapCoverage('or/require-or', api, this.provider);
     coverage.addContract(contract.instrumented, util.filePath);
-    await contract.instance.a(1);
+    await contract.instance.a(1, contract.gas);
 
     const mapping = coverage.generate(contract.data, util.pathPrefix);
 
@@ -88,10 +83,10 @@ describe('logical OR branches', () => {
   //   x == 3
   // )
   it('should cover a require statement with multiline OR condition (two branches)', async function() {
-    const contract = await util.bootstrapCoverage('or/require-multiline-or', api);
+    const contract = await util.bootstrapCoverage('or/require-multiline-or', api, this.provider);
     coverage.addContract(contract.instrumented, util.filePath);
-    await contract.instance.a(1);
-    await contract.instance.a(3);
+    await contract.instance.a(1, contract.gas);
+    await contract.instance.a(3, contract.gas);
 
     const mapping = coverage.generate(contract.data, util.pathPrefix);
 
@@ -111,10 +106,10 @@ describe('logical OR branches', () => {
 
   // require(x == 1 || x == 2)
   it('should cover a require statement with a simple OR condition (both branches)', async function() {
-    const contract = await util.bootstrapCoverage('or/require-or', api);
+    const contract = await util.bootstrapCoverage('or/require-or', api, this.provider);
     coverage.addContract(contract.instrumented, util.filePath);
-    await contract.instance.a(1);
-    await contract.instance.a(2);
+    await contract.instance.a(1, contract.gas);
+    await contract.instance.a(2, contract.gas);
 
     const mapping = coverage.generate(contract.data, util.pathPrefix);
 
@@ -134,9 +129,9 @@ describe('logical OR branches', () => {
 
   // while( (x == 1 || x == 2) && counter < 2 ){
   it('should cover a while statement with a simple OR condition (single branch)', async function() {
-    const contract = await util.bootstrapCoverage('or/while-or', api);
+    const contract = await util.bootstrapCoverage('or/while-or', api, this.provider);
     coverage.addContract(contract.instrumented, util.filePath);
-    await contract.instance.a(1);
+    await contract.instance.a(1, contract.gas);
 
     const mapping = coverage.generate(contract.data, util.pathPrefix);
 
@@ -156,10 +151,10 @@ describe('logical OR branches', () => {
 
   // while( (x == 1 || x == 2) && counter < 2 ){
   it('should cover a while statement with a simple OR condition (both branches)', async function() {
-    const contract = await util.bootstrapCoverage('or/while-or', api);
+    const contract = await util.bootstrapCoverage('or/while-or', api, this.provider);
     coverage.addContract(contract.instrumented, util.filePath);
-    await contract.instance.a(1);
-    await contract.instance.a(2);
+    await contract.instance.a(1, contract.gas);
+    await contract.instance.a(2, contract.gas);
 
     const mapping = coverage.generate(contract.data, util.pathPrefix);
 
@@ -179,9 +174,9 @@ describe('logical OR branches', () => {
 
   // return (x == 1 && true) || (x == 2 && true);
   it('should cover a return statement with ANDED OR conditions (single branch)', async function() {
-    const contract = await util.bootstrapCoverage('or/return-or', api);
+    const contract = await util.bootstrapCoverage('or/return-or', api, this.provider);
     coverage.addContract(contract.instrumented, util.filePath);
-    await contract.instance.a(1);
+    await contract.instance.a(1, contract.gas);
 
     const mapping = coverage.generate(contract.data, util.pathPrefix);
 
@@ -201,10 +196,10 @@ describe('logical OR branches', () => {
 
   // return (x == 1 && true) || (x == 2 && true);
   it('should cover a return statement with ANDED OR conditions (both branches)', async function() {
-    const contract = await util.bootstrapCoverage('or/return-or', api);
+    const contract = await util.bootstrapCoverage('or/return-or', api, this.provider);
     coverage.addContract(contract.instrumented, util.filePath);
-    await contract.instance.a(1);
-    await contract.instance.a(2);
+    await contract.instance.a(1, contract.gas);
+    await contract.instance.a(2, contract.gas);
 
     const mapping = coverage.generate(contract.data, util.pathPrefix);
 
@@ -224,9 +219,9 @@ describe('logical OR branches', () => {
 
   //if (x == 1 && true || x == 2) {
   it('should cover an if statement with OR and AND conditions (single branch)', async function() {
-    const contract = await util.bootstrapCoverage('or/and-or', api);
+    const contract = await util.bootstrapCoverage('or/and-or', api, this.provider);
     coverage.addContract(contract.instrumented, util.filePath);
-    await contract.instance.a(1);
+    await contract.instance.a(1, contract.gas);
 
     const mapping = coverage.generate(contract.data, util.pathPrefix);
 
@@ -246,10 +241,10 @@ describe('logical OR branches', () => {
 
   //if (x == 1 && true || x == 2) {
   it('should cover an if statement with OR and AND conditions (both branches)', async function() {
-    const contract = await util.bootstrapCoverage('or/and-or', api);
+    const contract = await util.bootstrapCoverage('or/and-or', api, this.provider);
     coverage.addContract(contract.instrumented, util.filePath);
-    await contract.instance.a(1);
-    await contract.instance.a(2);
+    await contract.instance.a(1, contract.gas);
+    await contract.instance.a(2, contract.gas);
 
     const mapping = coverage.generate(contract.data, util.pathPrefix);
 
@@ -269,9 +264,9 @@ describe('logical OR branches', () => {
 
   // if ((x == 1) && (x == 2 || true)) {
   it('should cover an if statement with bracked ANDED OR conditions (rightmost sub-branch)', async function() {
-    const contract = await util.bootstrapCoverage('or/and-or-brackets', api);
+    const contract = await util.bootstrapCoverage('or/and-or-brackets', api, this.provider);
     coverage.addContract(contract.instrumented, util.filePath);
-    await contract.instance.a(1);
+    await contract.instance.a(1, contract.gas);
 
     const mapping = coverage.generate(contract.data, util.pathPrefix);
 
@@ -291,9 +286,9 @@ describe('logical OR branches', () => {
 
   // if ((x == 1) || (x == 2 || true)) {
   it('should cover an if statement with multiple (bracketed) OR conditions (branch 1)', async function() {
-    const contract = await util.bootstrapCoverage('or/multi-or', api);
+    const contract = await util.bootstrapCoverage('or/multi-or', api, this.provider);
     coverage.addContract(contract.instrumented, util.filePath);
-    await contract.instance.a(1);
+    await contract.instance.a(1, contract.gas);
 
     const mapping = coverage.generate(contract.data, util.pathPrefix);
 
@@ -313,9 +308,9 @@ describe('logical OR branches', () => {
 
   // if ((x == 1) || (x == 2 || true)) {
   it('should cover an if statement with multiple (bracketed) OR conditions (branch 2)', async function() {
-    const contract = await util.bootstrapCoverage('or/multi-or', api);
+    const contract = await util.bootstrapCoverage('or/multi-or', api, this.provider);
     coverage.addContract(contract.instrumented, util.filePath);
-    await contract.instance.a(2);
+    await contract.instance.a(2, contract.gas);
 
     const mapping = coverage.generate(contract.data, util.pathPrefix);
 
@@ -335,9 +330,9 @@ describe('logical OR branches', () => {
 
   // if ((x == 1) || (x == 2 || true)) {
   it('should cover an if statement with multiple (bracketed) OR conditions (branch 3)', async function() {
-    const contract = await util.bootstrapCoverage('or/multi-or', api);
+    const contract = await util.bootstrapCoverage('or/multi-or', api, this.provider);
     coverage.addContract(contract.instrumented, util.filePath);
-    await contract.instance.a(3);
+    await contract.instance.a(3, contract.gas);
 
     const mapping = coverage.generate(contract.data, util.pathPrefix);
 
@@ -356,9 +351,9 @@ describe('logical OR branches', () => {
   });
 
   it('should cover the bzx example', async function(){
-    const contract = await util.bootstrapCoverage('or/bzx-or', api);
+    const contract = await util.bootstrapCoverage('or/bzx-or', api, this.provider);
     coverage.addContract(contract.instrumented, util.filePath);
-    await contract.instance.a(3);
+    await contract.instance.a(3, contract.gas);
 
     const mapping = coverage.generate(contract.data, util.pathPrefix);
 

--- a/test/units/statements.js
+++ b/test/units/statements.js
@@ -1,7 +1,5 @@
 const assert = require('assert');
 const util = require('./../util/util.js');
-
-const client = require('ganache-cli');
 const Coverage = require('./../../lib/coverage');
 const Api = require('./../../lib/api')
 
@@ -9,10 +7,7 @@ describe('generic statements', () => {
   let coverage;
   let api;
 
-  before(async () => {
-    api = new Api({silent: true});
-    await api.ganache(client);
-  })
+  before(async () => api = new Api({silent: true}))
   beforeEach(() => coverage = new Coverage());
   after(async() => await api.finish());
 
@@ -88,9 +83,9 @@ describe('generic statements', () => {
   });
 
   it('should cover an emitted event statement', async function() {
-    const contract = await util.bootstrapCoverage('statements/emit-coverage', api);
+    const contract = await util.bootstrapCoverage('statements/emit-coverage', api, this.provider);
     coverage.addContract(contract.instrumented, util.filePath);
-    await contract.instance.a(0);
+    await contract.instance.a(0, contract.gas);
     const mapping = coverage.generate(contract.data, util.pathPrefix);
 
     assert.deepEqual(mapping[util.filePath].l, {
@@ -106,9 +101,9 @@ describe('generic statements', () => {
   });
 
   it('should cover a statement following a close brace', async function() {
-    const contract = await util.bootstrapCoverage('statements/post-close-brace', api);
+    const contract = await util.bootstrapCoverage('statements/post-close-brace', api, this.provider);
     coverage.addContract(contract.instrumented, util.filePath);
-    await contract.instance.a(1);
+    await contract.instance.a(1, contract.gas);
     const mapping = coverage.generate(contract.data, util.pathPrefix);
 
     assert.deepEqual(mapping[util.filePath].l, {
@@ -126,9 +121,9 @@ describe('generic statements', () => {
   });
 
   it('should cover a library statement and an invoked library method', async function() {
-    const contract = await util.bootstrapCoverage('statements/library', api);
+    const contract = await util.bootstrapCoverage('statements/library', api, this.provider);
     coverage.addContract(contract.instrumented, util.filePath);
-    await contract.instance.not();
+    await contract.instance.not(contract.gas);
     const mapping = coverage.generate(contract.data, util.pathPrefix);
 
     assert.deepEqual(mapping[util.filePath].l, {
@@ -144,9 +139,9 @@ describe('generic statements', () => {
   });
 
   it('should cover a tuple statement', async function() {
-    const contract = await util.bootstrapCoverage('statements/tuple', api);
+    const contract = await util.bootstrapCoverage('statements/tuple', api, this.provider);
     coverage.addContract(contract.instrumented, util.filePath);
-    await contract.instance.a();
+    await contract.instance.a(contract.gas);
     const mapping = coverage.generate(contract.data, util.pathPrefix);
 
     assert.deepEqual(mapping[util.filePath].l, {
@@ -162,16 +157,16 @@ describe('generic statements', () => {
   });
 
   it.skip('should cover a unary statement', async function(){
-    const contract = await util.bootstrapCoverage('statements/unary', api);
+    const contract = await util.bootstrapCoverage('statements/unary', api, this.provider);
     coverage.addContract(contract.instrumented, util.filePath);
-    await contract.instance.a();
+    await contract.instance.a(contract.gas);
     const mapping = coverage.generate(contract.data, util.pathPrefix);
 
     // TODO: obtain both statements in unary.sol
   })
 
   it('should cover an empty bodied contract statement', async function() {
-    const contract = await util.bootstrapCoverage('statements/empty-contract-body', api);
+    const contract = await util.bootstrapCoverage('statements/empty-contract-body', api, this.provider);
     coverage.addContract(contract.instrumented, util.filePath);
     const mapping = coverage.generate(contract.data, util.pathPrefix);
 

--- a/test/util/mochaRootHook.js
+++ b/test/util/mochaRootHook.js
@@ -1,0 +1,14 @@
+const { createProvider } = require("hardhat/internal/core/providers/construction");
+const { resolveConfig } = require("hardhat/internal/core/config/config-resolution");
+const { HARDHAT_NETWORK_NAME } = require("hardhat/plugins")
+
+// Creates a shared, minimal HH provider for use in the unit tests
+exports.mochaHooks = {
+  beforeAll: async function() {
+    const config = await resolveConfig("./", {});
+    this.provider = await createProvider(
+      config,
+      HARDHAT_NETWORK_NAME
+    );
+  }
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1232,10 +1232,6 @@
   dependencies:
     defer-to-connect "^1.0.1"
 
-"@truffle/blockchain-utils@^0.0.13":
-  version "0.0.13"
-  resolved "https://registry.yarnpkg.com/@truffle/blockchain-utils/-/blockchain-utils-0.0.13.tgz#2b6302586248fe2068ba160be53855c3c923a4e2"
-
 "@truffle/blockchain-utils@^0.0.25":
   version "0.0.25"
   resolved "https://registry.yarnpkg.com/@truffle/blockchain-utils/-/blockchain-utils-0.0.25.tgz#f4b320890113d282f25f1a1ecd65b94a8b763ac1"
@@ -1259,27 +1255,12 @@
     utf8 "^3.0.0"
     web3-utils "1.2.9"
 
-"@truffle/contract-schema@^3.0.16", "@truffle/contract-schema@^3.2.5":
+"@truffle/contract-schema@^3.2.5":
   version "3.4.7"
   resolved "https://registry.yarnpkg.com/@truffle/contract-schema/-/contract-schema-3.4.7.tgz#8706e3a9f763891b1cfad5cde771e7f6175fa301"
   dependencies:
     ajv "^6.10.0"
     debug "^4.3.1"
-
-"@truffle/contract@4.0.36":
-  version "4.0.36"
-  resolved "https://registry.yarnpkg.com/@truffle/contract/-/contract-4.0.36.tgz#9c5d22034f034866f7566eb1ff6d46af0404090d"
-  dependencies:
-    "@truffle/blockchain-utils" "^0.0.13"
-    "@truffle/contract-schema" "^3.0.16"
-    "@truffle/error" "^0.0.7"
-    "@truffle/interface-adapter" "^0.2.7"
-    bignumber.js "^7.2.1"
-    ethers "^4.0.0-beta.1"
-    web3 "1.2.1"
-    web3-core-promievent "1.2.1"
-    web3-eth-abi "1.2.1"
-    web3-utils "1.2.1"
 
 "@truffle/debug-utils@^4.2.9":
   version "4.2.14"
@@ -1295,19 +1276,6 @@
 "@truffle/error@^0.0.11":
   version "0.0.11"
   resolved "https://registry.yarnpkg.com/@truffle/error/-/error-0.0.11.tgz#2789c0042d7e796dcbb840c7a9b5d2bcd8e0e2d8"
-
-"@truffle/error@^0.0.7":
-  version "0.0.7"
-  resolved "https://registry.yarnpkg.com/@truffle/error/-/error-0.0.7.tgz#e9db39885575647ef08bf624b0c13fe46d41a209"
-
-"@truffle/interface-adapter@^0.2.7":
-  version "0.2.7"
-  resolved "https://registry.yarnpkg.com/@truffle/interface-adapter/-/interface-adapter-0.2.7.tgz#43331d29539e09432a70cfb9fb614b8afaa7b290"
-  dependencies:
-    bn.js "^4.11.8"
-    ethers "^4.0.32"
-    lodash "^4.17.13"
-    web3 "1.2.1"
 
 "@truffle/interface-adapter@^0.4.16":
   version "0.4.24"
@@ -1408,7 +1376,7 @@
   version "17.0.27"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.27.tgz#f4df3981ae8268c066e8f49995639f855469081e"
 
-"@types/node@^10.0.3", "@types/node@^10.3.2":
+"@types/node@^10.0.3":
   version "10.17.60"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.60.tgz#35f3d6213daed95da7f0f73e75bcc6980e90597b"
 
@@ -1647,10 +1615,6 @@ ansi-styles@^4.0.0, ansi-styles@^4.1.0:
 antlr4ts@^0.5.0-alpha.4:
   version "0.5.0-alpha.4"
   resolved "https://registry.yarnpkg.com/antlr4ts/-/antlr4ts-0.5.0-alpha.4.tgz#71702865a87478ed0b40c0709f422cf14d51652a"
-
-any-promise@1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/any-promise/-/any-promise-1.3.0.tgz#abc6afeedcea52e809cdc0376aed3ce39635d17f"
 
 anymatch@~3.1.1, anymatch@~3.1.2:
   version "3.1.2"
@@ -2339,13 +2303,6 @@ bip39@2.5.0:
     safe-buffer "^5.0.1"
     unorm "^1.3.3"
 
-bl@^1.0.0:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/bl/-/bl-1.2.3.tgz#1e8dd80142eac80d7158c9dccc047fb620e035e7"
-  dependencies:
-    readable-stream "^2.3.5"
-    safe-buffer "^5.1.1"
-
 blakejs@^1.1.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/blakejs/-/blakejs-1.2.1.tgz#5057e4206eadb4a97f7c0b6e197a505042fc3814"
@@ -2362,7 +2319,7 @@ bn.js@4.11.8:
   version "4.11.8"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.8.tgz#2cde09eb5ee341f484746bb0309b3253b1b1442f"
 
-bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.10.0, bn.js@^4.11.0, bn.js@^4.11.6, bn.js@^4.11.8, bn.js@^4.11.9, bn.js@^4.4.0, bn.js@^4.8.0:
+bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.10.0, bn.js@^4.11.0, bn.js@^4.11.6, bn.js@^4.11.8, bn.js@^4.11.9, bn.js@^4.8.0:
   version "4.12.0"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.12.0.tgz#775b3f278efbb9718eec7361f483fb36fbbfea88"
 
@@ -2540,25 +2497,6 @@ bs58check@^2.1.2:
     bs58 "^4.0.0"
     create-hash "^1.1.0"
     safe-buffer "^5.1.2"
-
-buffer-alloc-unsafe@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz#bd7dc26ae2972d0eda253be061dba992349c19f0"
-
-buffer-alloc@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/buffer-alloc/-/buffer-alloc-1.2.0.tgz#890dd90d923a873e08e10e5fd51a57e5b7cce0ec"
-  dependencies:
-    buffer-alloc-unsafe "^1.1.0"
-    buffer-fill "^1.0.0"
-
-buffer-crc32@~0.2.3:
-  version "0.2.13"
-  resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
-
-buffer-fill@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/buffer-fill/-/buffer-fill-1.0.0.tgz#f8f78b76789888ef39f205cd637f68e702122b2c"
 
 buffer-from@^1.0.0:
   version "1.1.2"
@@ -2963,7 +2901,7 @@ commander@3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/commander/-/commander-3.0.2.tgz#6837c3fb677ad9933d1cfba42dd14d5117d6b39e"
 
-commander@^2.15.0, commander@^2.8.1:
+commander@^2.15.0:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
 
@@ -3224,54 +3162,6 @@ decompress-response@^3.2.0, decompress-response@^3.3.0:
   dependencies:
     mimic-response "^1.0.0"
 
-decompress-tar@^4.0.0, decompress-tar@^4.1.0, decompress-tar@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/decompress-tar/-/decompress-tar-4.1.1.tgz#718cbd3fcb16209716e70a26b84e7ba4592e5af1"
-  dependencies:
-    file-type "^5.2.0"
-    is-stream "^1.1.0"
-    tar-stream "^1.5.2"
-
-decompress-tarbz2@^4.0.0:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/decompress-tarbz2/-/decompress-tarbz2-4.1.1.tgz#3082a5b880ea4043816349f378b56c516be1a39b"
-  dependencies:
-    decompress-tar "^4.1.0"
-    file-type "^6.1.0"
-    is-stream "^1.1.0"
-    seek-bzip "^1.0.5"
-    unbzip2-stream "^1.0.9"
-
-decompress-targz@^4.0.0:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/decompress-targz/-/decompress-targz-4.1.1.tgz#c09bc35c4d11f3de09f2d2da53e9de23e7ce1eee"
-  dependencies:
-    decompress-tar "^4.1.1"
-    file-type "^5.2.0"
-    is-stream "^1.1.0"
-
-decompress-unzip@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/decompress-unzip/-/decompress-unzip-4.0.1.tgz#deaaccdfd14aeaf85578f733ae8210f9b4848f69"
-  dependencies:
-    file-type "^3.8.0"
-    get-stream "^2.2.0"
-    pify "^2.3.0"
-    yauzl "^2.4.2"
-
-decompress@^4.0.0:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/decompress/-/decompress-4.2.1.tgz#007f55cc6a62c055afa37c07eb6a4ee1b773f118"
-  dependencies:
-    decompress-tar "^4.0.0"
-    decompress-tarbz2 "^4.0.0"
-    decompress-targz "^4.0.0"
-    decompress-unzip "^4.0.1"
-    graceful-fs "^4.1.10"
-    make-dir "^1.0.0"
-    pify "^2.3.0"
-    strip-dirs "^2.0.0"
-
 deep-eql@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-3.0.1.tgz#dfc9404400ad1c8fe023e7da1df1c147c4b444df"
@@ -3469,15 +3359,6 @@ electron-to-chromium@^1.3.47:
   version "1.4.121"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.121.tgz#e2fa3b7bd592643c6b12ae6de2882550a29b7799"
 
-elliptic@6.3.3:
-  version "6.3.3"
-  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.3.3.tgz#5482d9646d54bcb89fd7d994fc9e2e9568876e3f"
-  dependencies:
-    bn.js "^4.4.0"
-    brorand "^1.0.1"
-    hash.js "^1.0.0"
-    inherits "^2.0.1"
-
 elliptic@6.5.4, elliptic@^6.4.0, elliptic@^6.5.2, elliptic@^6.5.3, elliptic@^6.5.4:
   version "6.5.4"
   resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.4.tgz#da37cebd31e79a1367e941b592ed1fbebd58abbb"
@@ -3518,7 +3399,7 @@ encoding@^0.1.11:
   dependencies:
     iconv-lite "^0.6.2"
 
-end-of-stream@^1.0.0, end-of-stream@^1.1.0:
+end-of-stream@^1.1.0:
   version "1.4.4"
   resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.4.tgz#5ae64a5f45057baf3626ec14da0ca5e4b2431eb0"
   dependencies:
@@ -4051,21 +3932,6 @@ ethereumjs-wallet@0.6.5:
     utf8 "^3.0.0"
     uuid "^3.3.2"
 
-ethers@4.0.0-beta.3:
-  version "4.0.0-beta.3"
-  resolved "https://registry.yarnpkg.com/ethers/-/ethers-4.0.0-beta.3.tgz#15bef14e57e94ecbeb7f9b39dd0a4bd435bc9066"
-  dependencies:
-    "@types/node" "^10.3.2"
-    aes-js "3.0.0"
-    bn.js "^4.4.0"
-    elliptic "6.3.3"
-    hash.js "1.1.3"
-    js-sha3 "0.5.7"
-    scrypt-js "2.0.3"
-    setimmediate "1.0.4"
-    uuid "2.0.1"
-    xmlhttprequest "1.8.0"
-
 ethers@^4.0.0-beta.1, ethers@^4.0.32, ethers@^4.0.40:
   version "4.0.49"
   resolved "https://registry.yarnpkg.com/ethers/-/ethers-4.0.49.tgz#0eb0e9161a0c8b4761be547396bbe2fb121a8894"
@@ -4163,10 +4029,6 @@ ethjs-util@0.1.6, ethjs-util@^0.1.3, ethjs-util@^0.1.6:
   dependencies:
     is-hex-prefixed "1.0.0"
     strip-hex-prefix "1.0.0"
-
-eventemitter3@3.1.2:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-3.1.2.tgz#2d3d48f9c346698fce83a85d7d664e98535df6e7"
 
 eventemitter3@4.0.4:
   version "4.0.4"
@@ -4321,29 +4183,11 @@ fastq@^1.6.0:
   dependencies:
     reusify "^1.0.4"
 
-fd-slicer@~1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/fd-slicer/-/fd-slicer-1.1.0.tgz#25c7c89cb1f9077f8891bbe61d8f390eae256f1e"
-  dependencies:
-    pend "~1.2.0"
-
 fetch-ponyfill@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/fetch-ponyfill/-/fetch-ponyfill-4.1.0.tgz#ae3ce5f732c645eab87e4ae8793414709b239893"
   dependencies:
     node-fetch "~1.7.1"
-
-file-type@^3.8.0:
-  version "3.9.0"
-  resolved "https://registry.yarnpkg.com/file-type/-/file-type-3.9.0.tgz#257a078384d1db8087bc449d107d52a52672b9e9"
-
-file-type@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/file-type/-/file-type-5.2.0.tgz#2ddbea7c73ffe36368dfae49dc338c058c2b8ad6"
-
-file-type@^6.1.0:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/file-type/-/file-type-6.2.0.tgz#e50cd75d356ffed4e306dc4f5bcf52a79903a919"
 
 fill-range@^4.0.0:
   version "4.0.0"
@@ -4515,10 +4359,6 @@ fresh@0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
 
-fs-constants@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/fs-constants/-/fs-constants-1.0.0.tgz#6be0de9be998ce16af8afc24497b9ee9b7ccd9ad"
-
 fs-extra@^0.30.0:
   version "0.30.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-0.30.0.tgz#f233ffcc08d4da7d432daa449776989db1df93f0"
@@ -4654,13 +4494,6 @@ get-intrinsic@^1.0.2, get-intrinsic@^1.1.0, get-intrinsic@^1.1.1:
 get-port@^3.1.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/get-port/-/get-port-3.2.0.tgz#dd7ce7de187c06c8bf353796ac71e099f0980ebc"
-
-get-stream@^2.2.0:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-2.3.1.tgz#5f38f93f346009666ee0150a054167f91bdd95de"
-  dependencies:
-    object-assign "^4.0.1"
-    pinkie-promise "^2.0.0"
 
 get-stream@^3.0.0:
   version "3.0.0"
@@ -4817,7 +4650,7 @@ got@^7.1.0:
     url-parse-lax "^1.0.0"
     url-to-options "^1.0.1"
 
-graceful-fs@^4.1.10, graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9, graceful-fs@^4.2.0:
+graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9, graceful-fs@^4.2.0:
   version "4.2.10"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.10.tgz#147d3a006da4ca3ce14728c7aefc287c367d7a6c"
 
@@ -5378,10 +5211,6 @@ is-glob@^4.0.1, is-glob@~4.0.1:
 is-hex-prefixed@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-hex-prefixed/-/is-hex-prefixed-1.0.0.tgz#7d8d37e6ad77e5d127148913c573e082d777f554"
-
-is-natural-number@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/is-natural-number/-/is-natural-number-4.0.1.tgz#ab9d76e1db4ced51e35de0c72ebecf09f734cde8"
 
 is-negative-zero@^2.0.2:
   version "2.0.2"
@@ -6006,7 +5835,7 @@ lodash@4.17.20:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
 
-lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.21, lodash@^4.17.4:
+lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.21, lodash@^4.17.4:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
 
@@ -6087,12 +5916,6 @@ ltgt@^2.1.2, ltgt@~2.2.0:
 ltgt@~2.1.1:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ltgt/-/ltgt-2.1.3.tgz#10851a06d9964b971178441c23c9e52698eece34"
-
-make-dir@^1.0.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-1.3.0.tgz#79c1033b80515bd6d24ec9933e860ca75ee27f0c"
-  dependencies:
-    pify "^3.0.0"
 
 make-dir@^2.0.0, make-dir@^2.1.0:
   version "2.1.0"
@@ -6505,10 +6328,6 @@ multihashes@^0.4.15, multihashes@~0.4.15:
     multibase "^0.7.0"
     varint "^5.0.0"
 
-nan@^2.14.0:
-  version "2.15.0"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.15.0.tgz#3f34a473ff18e15c1b5626b62903b5ad6e665fee"
-
 nano-json-stream-parser@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/nano-json-stream-parser/-/nano-json-stream-parser-0.1.2.tgz#0cc8f6d0e2b622b479c40d499c46d64b755c6f5f"
@@ -6671,7 +6490,7 @@ oauth-sign@~0.9.0:
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
 
-object-assign@^4, object-assign@^4.0.0, object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
+object-assign@^4, object-assign@^4.0.0, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
@@ -7047,10 +6866,6 @@ pbkdf2@^3.0.17, pbkdf2@^3.0.3, pbkdf2@^3.0.9:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-pend@~1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
-
 performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
@@ -7269,10 +7084,6 @@ randomfill@^1.0.3:
     randombytes "^2.0.5"
     safe-buffer "^5.1.0"
 
-randomhex@0.1.5:
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/randomhex/-/randomhex-0.1.5.tgz#baceef982329091400f2a2912c6cd02f1094f585"
-
 range-parser@~1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.1.tgz#3cf37023d199e1c24d1a55b84800c2f3e6468031"
@@ -7325,7 +7136,7 @@ readable-stream@^1.0.33:
     isarray "0.0.1"
     string_decoder "~0.10.x"
 
-readable-stream@^2.0.0, readable-stream@^2.0.5, readable-stream@^2.2.2, readable-stream@^2.2.8, readable-stream@^2.2.9, readable-stream@^2.3.0, readable-stream@^2.3.5, readable-stream@^2.3.6, readable-stream@~2.3.6:
+readable-stream@^2.0.0, readable-stream@^2.0.5, readable-stream@^2.2.2, readable-stream@^2.2.8, readable-stream@^2.2.9, readable-stream@^2.3.6, readable-stream@~2.3.6:
   version "2.3.7"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
   dependencies:
@@ -7646,10 +7457,6 @@ sc-istanbul@^0.4.5:
     which "^1.1.1"
     wordwrap "^1.0.0"
 
-scrypt-js@2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/scrypt-js/-/scrypt-js-2.0.3.tgz#bb0040be03043da9a012a2cea9fc9f852cfc87d4"
-
 scrypt-js@2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/scrypt-js/-/scrypt-js-2.0.4.tgz#32f8c5149f0797672e551c07e230f834b6af5f16"
@@ -7657,10 +7464,6 @@ scrypt-js@2.0.4:
 scrypt-js@3.0.1, scrypt-js@^3.0.0, scrypt-js@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/scrypt-js/-/scrypt-js-3.0.1.tgz#d314a57c2aef69d1ad98a138a21fe9eafa9ee312"
-
-scryptsy@2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/scryptsy/-/scryptsy-2.1.0.tgz#8d1e8d0c025b58fdd25b6fa9a0dc905ee8faa790"
 
 scryptsy@^1.2.1:
   version "1.2.1"
@@ -7680,12 +7483,6 @@ seedrandom@3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/seedrandom/-/seedrandom-3.0.1.tgz#eb3dde015bcf55df05a233514e5df44ef9dce083"
 
-seek-bzip@^1.0.5:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/seek-bzip/-/seek-bzip-1.0.6.tgz#35c4171f55a680916b52a07859ecf3b5857f21c4"
-  dependencies:
-    commander "^2.8.1"
-
 semaphore@>=1.0.1, semaphore@^1.0.3, semaphore@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/semaphore/-/semaphore-1.1.0.tgz#aaad8b86b20fe8e9b32b16dc2ee682a8cd26a8aa"
@@ -7693,10 +7490,6 @@ semaphore@>=1.0.1, semaphore@^1.0.3, semaphore@^1.1.0:
 "semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.5.0, semver@^5.6.0, semver@^5.7.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
-
-semver@6.2.0:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-6.2.0.tgz#4d813d9590aaf8a9192693d6c85b9344de5901db"
 
 semver@^6.0.0, semver@^6.3.0:
   version "6.3.0"
@@ -8172,12 +7965,6 @@ strip-bom@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
 
-strip-dirs@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/strip-dirs/-/strip-dirs-2.1.0.tgz#4987736264fc344cf20f6c34aca9d13d1d4ed6c5"
-  dependencies:
-    is-natural-number "^4.0.1"
-
 strip-eof@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
@@ -8248,23 +8035,6 @@ supports-preserve-symlinks-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
 
-swarm-js@0.1.39:
-  version "0.1.39"
-  resolved "https://registry.yarnpkg.com/swarm-js/-/swarm-js-0.1.39.tgz#79becb07f291d4b2a178c50fee7aa6e10342c0e8"
-  dependencies:
-    bluebird "^3.5.0"
-    buffer "^5.0.5"
-    decompress "^4.0.0"
-    eth-lib "^0.1.26"
-    fs-extra "^4.0.2"
-    got "^7.1.0"
-    mime-types "^2.1.16"
-    mkdirp-promise "^5.0.1"
-    mock-fs "^4.1.0"
-    setimmediate "^1.0.5"
-    tar "^4.0.2"
-    xhr-request-promise "^0.1.2"
-
 swarm-js@^0.1.40:
   version "0.1.40"
   resolved "https://registry.yarnpkg.com/swarm-js/-/swarm-js-0.1.40.tgz#b1bc7b6dcc76061f6c772203e004c11997e06b99"
@@ -8314,18 +8084,6 @@ tape@^4.6.3:
     resumer "~0.0.0"
     string.prototype.trim "~1.2.5"
     through "~2.3.8"
-
-tar-stream@^1.5.2:
-  version "1.6.2"
-  resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-1.6.2.tgz#8ea55dab37972253d9a9af90fdcd559ae435c555"
-  dependencies:
-    bl "^1.0.0"
-    buffer-alloc "^1.2.0"
-    end-of-stream "^1.0.0"
-    fs-constants "^1.0.0"
-    readable-stream "^2.3.0"
-    to-buffer "^1.1.1"
-    xtend "^4.0.0"
 
 tar@^4.0.2:
   version "4.4.19"
@@ -8382,7 +8140,7 @@ through2@^2.0.3:
     readable-stream "~2.3.6"
     xtend "~4.0.1"
 
-through@^2.3.8, through@~2.3.4, through@~2.3.8:
+through@~2.3.4, through@~2.3.8:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
 
@@ -8401,10 +8159,6 @@ tmp@0.1.0:
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.1.0.tgz#ee434a4e22543082e294ba6201dcc6eafefa2877"
   dependencies:
     rimraf "^2.6.3"
-
-to-buffer@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/to-buffer/-/to-buffer-1.1.1.tgz#493bd48f62d7c43fcded313a03dcadb2e1213a80"
 
 to-fast-properties@^1.0.3:
   version "1.0.3"
@@ -8611,13 +8365,6 @@ unbox-primitive@^1.0.1:
     has-symbols "^1.0.3"
     which-boxed-primitive "^1.0.2"
 
-unbzip2-stream@^1.0.9:
-  version "1.4.3"
-  resolved "https://registry.yarnpkg.com/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz#b0da04c4371311df771cdc215e87f2130991ace7"
-  dependencies:
-    buffer "^5.2.1"
-    through "^2.3.8"
-
 underscore@1.12.1:
   version "1.12.1"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.12.1.tgz#7bb8cc9b3d397e201cf8553336d262544ead829e"
@@ -8783,14 +8530,6 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-web3-bzz@1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/web3-bzz/-/web3-bzz-1.2.1.tgz#c3bd1e8f0c02a13cd6d4e3c3e9e1713f144f6f0d"
-  dependencies:
-    got "9.6.0"
-    swarm-js "0.1.39"
-    underscore "1.9.1"
-
 web3-bzz@1.2.11:
   version "1.2.11"
   resolved "https://registry.yarnpkg.com/web3-bzz/-/web3-bzz-1.2.11.tgz#41bc19a77444bd5365744596d778b811880f707f"
@@ -8817,14 +8556,6 @@ web3-bzz@1.7.3:
     got "9.6.0"
     swarm-js "^0.1.40"
 
-web3-core-helpers@1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/web3-core-helpers/-/web3-core-helpers-1.2.1.tgz#f5f32d71c60a4a3bd14786118e633ce7ca6d5d0d"
-  dependencies:
-    underscore "1.9.1"
-    web3-eth-iban "1.2.1"
-    web3-utils "1.2.1"
-
 web3-core-helpers@1.2.11:
   version "1.2.11"
   resolved "https://registry.yarnpkg.com/web3-core-helpers/-/web3-core-helpers-1.2.11.tgz#84c681ed0b942c0203f3b324a245a127e8c67a99"
@@ -8847,16 +8578,6 @@ web3-core-helpers@1.7.3:
   dependencies:
     web3-eth-iban "1.7.3"
     web3-utils "1.7.3"
-
-web3-core-method@1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/web3-core-method/-/web3-core-method-1.2.1.tgz#9df1bafa2cd8be9d9937e01c6a47fc768d15d90a"
-  dependencies:
-    underscore "1.9.1"
-    web3-core-helpers "1.2.1"
-    web3-core-promievent "1.2.1"
-    web3-core-subscriptions "1.2.1"
-    web3-utils "1.2.1"
 
 web3-core-method@1.2.11:
   version "1.2.11"
@@ -8890,13 +8611,6 @@ web3-core-method@1.7.3:
     web3-core-subscriptions "1.7.3"
     web3-utils "1.7.3"
 
-web3-core-promievent@1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/web3-core-promievent/-/web3-core-promievent-1.2.1.tgz#003e8a3eb82fb27b6164a6d5b9cad04acf733838"
-  dependencies:
-    any-promise "1.3.0"
-    eventemitter3 "3.1.2"
-
 web3-core-promievent@1.2.11:
   version "1.2.11"
   resolved "https://registry.yarnpkg.com/web3-core-promievent/-/web3-core-promievent-1.2.11.tgz#51fe97ca0ddec2f99bf8c3306a7a8e4b094ea3cf"
@@ -8914,16 +8628,6 @@ web3-core-promievent@1.7.3:
   resolved "https://registry.yarnpkg.com/web3-core-promievent/-/web3-core-promievent-1.7.3.tgz#2d0eeef694569b61355054c721578f67df925b80"
   dependencies:
     eventemitter3 "4.0.4"
-
-web3-core-requestmanager@1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/web3-core-requestmanager/-/web3-core-requestmanager-1.2.1.tgz#fa2e2206c3d738db38db7c8fe9c107006f5c6e3d"
-  dependencies:
-    underscore "1.9.1"
-    web3-core-helpers "1.2.1"
-    web3-providers-http "1.2.1"
-    web3-providers-ipc "1.2.1"
-    web3-providers-ws "1.2.1"
 
 web3-core-requestmanager@1.2.11:
   version "1.2.11"
@@ -8956,14 +8660,6 @@ web3-core-requestmanager@1.7.3:
     web3-providers-ipc "1.7.3"
     web3-providers-ws "1.7.3"
 
-web3-core-subscriptions@1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/web3-core-subscriptions/-/web3-core-subscriptions-1.2.1.tgz#8c2368a839d4eec1c01a4b5650bbeb82d0e4a099"
-  dependencies:
-    eventemitter3 "3.1.2"
-    underscore "1.9.1"
-    web3-core-helpers "1.2.1"
-
 web3-core-subscriptions@1.2.11:
   version "1.2.11"
   resolved "https://registry.yarnpkg.com/web3-core-subscriptions/-/web3-core-subscriptions-1.2.11.tgz#beca908fbfcb050c16f45f3f0f4c205e8505accd"
@@ -8986,15 +8682,6 @@ web3-core-subscriptions@1.7.3:
   dependencies:
     eventemitter3 "4.0.4"
     web3-core-helpers "1.7.3"
-
-web3-core@1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/web3-core/-/web3-core-1.2.1.tgz#7278b58fb6495065e73a77efbbce781a7fddf1a9"
-  dependencies:
-    web3-core-helpers "1.2.1"
-    web3-core-method "1.2.1"
-    web3-core-requestmanager "1.2.1"
-    web3-utils "1.2.1"
 
 web3-core@1.2.11:
   version "1.2.11"
@@ -9032,14 +8719,6 @@ web3-core@1.7.3:
     web3-core-requestmanager "1.7.3"
     web3-utils "1.7.3"
 
-web3-eth-abi@1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/web3-eth-abi/-/web3-eth-abi-1.2.1.tgz#9b915b1c9ebf82f70cca631147035d5419064689"
-  dependencies:
-    ethers "4.0.0-beta.3"
-    underscore "1.9.1"
-    web3-utils "1.2.1"
-
 web3-eth-abi@1.2.11:
   version "1.2.11"
   resolved "https://registry.yarnpkg.com/web3-eth-abi/-/web3-eth-abi-1.2.11.tgz#a887494e5d447c2926d557a3834edd66e17af9b0"
@@ -9062,22 +8741,6 @@ web3-eth-abi@1.7.3:
   dependencies:
     "@ethersproject/abi" "5.0.7"
     web3-utils "1.7.3"
-
-web3-eth-accounts@1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/web3-eth-accounts/-/web3-eth-accounts-1.2.1.tgz#2741a8ef337a7219d57959ac8bd118b9d68d63cf"
-  dependencies:
-    any-promise "1.3.0"
-    crypto-browserify "3.12.0"
-    eth-lib "0.2.7"
-    scryptsy "2.1.0"
-    semver "6.2.0"
-    underscore "1.9.1"
-    uuid "3.3.2"
-    web3-core "1.2.1"
-    web3-core-helpers "1.2.1"
-    web3-core-method "1.2.1"
-    web3-utils "1.2.1"
 
 web3-eth-accounts@1.2.11:
   version "1.2.11"
@@ -9127,19 +8790,6 @@ web3-eth-accounts@1.7.3:
     web3-core-method "1.7.3"
     web3-utils "1.7.3"
 
-web3-eth-contract@1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/web3-eth-contract/-/web3-eth-contract-1.2.1.tgz#3542424f3d341386fd9ff65e78060b85ac0ea8c4"
-  dependencies:
-    underscore "1.9.1"
-    web3-core "1.2.1"
-    web3-core-helpers "1.2.1"
-    web3-core-method "1.2.1"
-    web3-core-promievent "1.2.1"
-    web3-core-subscriptions "1.2.1"
-    web3-eth-abi "1.2.1"
-    web3-utils "1.2.1"
-
 web3-eth-contract@1.2.11:
   version "1.2.11"
   resolved "https://registry.yarnpkg.com/web3-eth-contract/-/web3-eth-contract-1.2.11.tgz#917065902bc27ce89da9a1da26e62ef663663b90"
@@ -9180,19 +8830,6 @@ web3-eth-contract@1.7.3:
     web3-core-subscriptions "1.7.3"
     web3-eth-abi "1.7.3"
     web3-utils "1.7.3"
-
-web3-eth-ens@1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/web3-eth-ens/-/web3-eth-ens-1.2.1.tgz#a0e52eee68c42a8b9865ceb04e5fb022c2d971d5"
-  dependencies:
-    eth-ens-namehash "2.0.8"
-    underscore "1.9.1"
-    web3-core "1.2.1"
-    web3-core-helpers "1.2.1"
-    web3-core-promievent "1.2.1"
-    web3-eth-abi "1.2.1"
-    web3-eth-contract "1.2.1"
-    web3-utils "1.2.1"
 
 web3-eth-ens@1.2.11:
   version "1.2.11"
@@ -9235,13 +8872,6 @@ web3-eth-ens@1.7.3:
     web3-eth-contract "1.7.3"
     web3-utils "1.7.3"
 
-web3-eth-iban@1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/web3-eth-iban/-/web3-eth-iban-1.2.1.tgz#2c3801718946bea24e9296993a975c80b5acf880"
-  dependencies:
-    bn.js "4.11.8"
-    web3-utils "1.2.1"
-
 web3-eth-iban@1.2.11:
   version "1.2.11"
   resolved "https://registry.yarnpkg.com/web3-eth-iban/-/web3-eth-iban-1.2.11.tgz#f5f73298305bc7392e2f188bf38a7362b42144ef"
@@ -9262,16 +8892,6 @@ web3-eth-iban@1.7.3:
   dependencies:
     bn.js "^4.11.9"
     web3-utils "1.7.3"
-
-web3-eth-personal@1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/web3-eth-personal/-/web3-eth-personal-1.2.1.tgz#244e9911b7b482dc17c02f23a061a627c6e47faf"
-  dependencies:
-    web3-core "1.2.1"
-    web3-core-helpers "1.2.1"
-    web3-core-method "1.2.1"
-    web3-net "1.2.1"
-    web3-utils "1.2.1"
 
 web3-eth-personal@1.2.11:
   version "1.2.11"
@@ -9305,24 +8925,6 @@ web3-eth-personal@1.7.3:
     web3-core-method "1.7.3"
     web3-net "1.7.3"
     web3-utils "1.7.3"
-
-web3-eth@1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/web3-eth/-/web3-eth-1.2.1.tgz#b9989e2557c73a9e8ffdc107c6dafbe72c79c1b0"
-  dependencies:
-    underscore "1.9.1"
-    web3-core "1.2.1"
-    web3-core-helpers "1.2.1"
-    web3-core-method "1.2.1"
-    web3-core-subscriptions "1.2.1"
-    web3-eth-abi "1.2.1"
-    web3-eth-accounts "1.2.1"
-    web3-eth-contract "1.2.1"
-    web3-eth-ens "1.2.1"
-    web3-eth-iban "1.2.1"
-    web3-eth-personal "1.2.1"
-    web3-net "1.2.1"
-    web3-utils "1.2.1"
 
 web3-eth@1.2.11:
   version "1.2.11"
@@ -9377,14 +8979,6 @@ web3-eth@1.7.3:
     web3-net "1.7.3"
     web3-utils "1.7.3"
 
-web3-net@1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/web3-net/-/web3-net-1.2.1.tgz#edd249503315dd5ab4fa00220f6509d95bb7ab10"
-  dependencies:
-    web3-core "1.2.1"
-    web3-core-method "1.2.1"
-    web3-utils "1.2.1"
-
 web3-net@1.2.11:
   version "1.2.11"
   resolved "https://registry.yarnpkg.com/web3-net/-/web3-net-1.2.11.tgz#eda68ef25e5cdb64c96c39085cdb74669aabbe1b"
@@ -9434,13 +9028,6 @@ web3-provider-engine@14.2.1:
     xhr "^2.2.0"
     xtend "^4.0.1"
 
-web3-providers-http@1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/web3-providers-http/-/web3-providers-http-1.2.1.tgz#c93ea003a42e7b894556f7e19dd3540f947f5013"
-  dependencies:
-    web3-core-helpers "1.2.1"
-    xhr2-cookies "1.1.0"
-
 web3-providers-http@1.2.11:
   version "1.2.11"
   resolved "https://registry.yarnpkg.com/web3-providers-http/-/web3-providers-http-1.2.11.tgz#1cd03442c61670572d40e4dcdf1faff8bd91e7c6"
@@ -9461,14 +9048,6 @@ web3-providers-http@1.7.3:
   dependencies:
     web3-core-helpers "1.7.3"
     xhr2-cookies "1.1.0"
-
-web3-providers-ipc@1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/web3-providers-ipc/-/web3-providers-ipc-1.2.1.tgz#017bfc687a8fc5398df2241eb98f135e3edd672c"
-  dependencies:
-    oboe "2.1.4"
-    underscore "1.9.1"
-    web3-core-helpers "1.2.1"
 
 web3-providers-ipc@1.2.11:
   version "1.2.11"
@@ -9492,14 +9071,6 @@ web3-providers-ipc@1.7.3:
   dependencies:
     oboe "2.1.5"
     web3-core-helpers "1.7.3"
-
-web3-providers-ws@1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/web3-providers-ws/-/web3-providers-ws-1.2.1.tgz#2d941eaf3d5a8caa3214eff8dc16d96252b842cb"
-  dependencies:
-    underscore "1.9.1"
-    web3-core-helpers "1.2.1"
-    websocket "github:web3-js/WebSocket-Node#polyfill/globalThis"
 
 web3-providers-ws@1.2.11:
   version "1.2.11"
@@ -9527,15 +9098,6 @@ web3-providers-ws@1.7.3:
     web3-core-helpers "1.7.3"
     websocket "^1.0.32"
 
-web3-shh@1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/web3-shh/-/web3-shh-1.2.1.tgz#4460e3c1e07faf73ddec24ccd00da46f89152b0c"
-  dependencies:
-    web3-core "1.2.1"
-    web3-core-method "1.2.1"
-    web3-core-subscriptions "1.2.1"
-    web3-net "1.2.1"
-
 web3-shh@1.2.11:
   version "1.2.11"
   resolved "https://registry.yarnpkg.com/web3-shh/-/web3-shh-1.2.11.tgz#f5d086f9621c9a47e98d438010385b5f059fd88f"
@@ -9562,18 +9124,6 @@ web3-shh@1.7.3:
     web3-core-method "1.7.3"
     web3-core-subscriptions "1.7.3"
     web3-net "1.7.3"
-
-web3-utils@1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/web3-utils/-/web3-utils-1.2.1.tgz#21466e38291551de0ab34558de21512ac4274534"
-  dependencies:
-    bn.js "4.11.8"
-    eth-lib "0.2.7"
-    ethjs-unit "0.1.6"
-    number-to-bn "1.7.0"
-    randomhex "0.1.5"
-    underscore "1.9.1"
-    utf8 "3.0.0"
 
 web3-utils@1.2.11:
   version "1.2.11"
@@ -9638,18 +9188,6 @@ web3-utils@^1.3.6:
     randombytes "^2.1.0"
     utf8 "3.0.0"
 
-web3@1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/web3/-/web3-1.2.1.tgz#5d8158bcca47838ab8c2b784a2dee4c3ceb4179b"
-  dependencies:
-    web3-bzz "1.2.1"
-    web3-core "1.2.1"
-    web3-eth "1.2.1"
-    web3-eth-personal "1.2.1"
-    web3-net "1.2.1"
-    web3-shh "1.2.1"
-    web3-utils "1.2.1"
-
 web3@1.2.11:
   version "1.2.11"
   resolved "https://registry.yarnpkg.com/web3/-/web3-1.2.11.tgz#50f458b2e8b11aa37302071c170ed61cff332975"
@@ -9710,16 +9248,6 @@ websocket@^1.0.31, websocket@^1.0.32:
     es5-ext "^0.10.50"
     typedarray-to-buffer "^3.1.5"
     utf-8-validate "^5.0.2"
-    yaeti "^0.0.6"
-
-"websocket@github:web3-js/WebSocket-Node#polyfill/globalThis":
-  version "1.0.29"
-  resolved "https://codeload.github.com/web3-js/WebSocket-Node/tar.gz/ef5ea2f41daf4a2113b80c9223df884b4d56c400"
-  dependencies:
-    debug "^2.2.0"
-    es5-ext "^0.10.50"
-    nan "^2.14.0"
-    typedarray-to-buffer "^3.1.5"
     yaeti "^0.0.6"
 
 whatwg-fetch@^2.0.4:
@@ -10028,13 +9556,6 @@ yargs@^4.7.1:
     window-size "^0.2.0"
     y18n "^3.2.1"
     yargs-parser "^2.4.1"
-
-yauzl@^2.4.2:
-  version "2.10.0"
-  resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-2.10.0.tgz#c7eb17c93e112cb1086fa6d8e51fb0667b79a5f9"
-  dependencies:
-    buffer-crc32 "~0.2.3"
-    fd-slicer "~1.1.0"
 
 yocto-queue@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
+ Replaces ganache client with a Hardhat provider in unit tests
+ Replaces truffle-contract with ethers in unit tests
+ Removes truffle/contract depedency

In tests that revert, the hit counts have had to be adjusted downwards because truffle-contract re-executed the transaction as a `call` to fetch the revert reason.