### PR TITLE
Use Node 20.11.0 in CircleCI for unit and integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ step_install_nvm: &step_install_nvm
 jobs:
   unit-test:
     docker:
-      - image: circleci/node:20
+      - image: cimg/node:20.11.0
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ step_install_nvm: &step_install_nvm
 jobs:
   unit-test:
     docker:
-      - image: circleci/node:14
+      - image: circleci/node:20
     steps:
       - checkout
       - run:


### PR DESCRIPTION
The e2e tests are staying on Node 14 for the moment...they still work (and might break or require e2e target updates if changed).