### PR TITLE
Fix test project configs for viaIR detection in overrides

### DIFF
--- a/test/sources/projects/hardhat-compile-config/hardhat.config.js
+++ b/test/sources/projects/hardhat-compile-config/hardhat.config.js
@@ -34,9 +34,9 @@ module.exports={
           optimizer: {
             enabled: true,
             runs: 200,
-            viaIR: process.env.VIA_IR === "true",
             evmVersion: 'paris'
-          }
+          },
+          viaIR: process.env.VIA_IR === "true",
         }
       }
     }

--- a/test/sources/projects/overrides-viaIR/hardhat.config.js
+++ b/test/sources/projects/overrides-viaIR/hardhat.config.js
@@ -18,9 +18,9 @@ module.exports={
           optimizer: {
             enabled: true,
             runs: 200,
-            viaIR: process.env.VIA_IR === "true",
             evmVersion: 'paris'
-          }
+          },
+          viaIR: process.env.VIA_IR === "true",
         }
       }
     }


### PR DESCRIPTION
`viaIR` was at the wrong level in the hardhat.config.js for these tests. (Codecov caught this - should tick up slightly)