### PR TITLE
Coerce sources path to absolute path if necessary

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,19 @@ step_install_nvm: &step_install_nvm
       nvm install v18
       echo 'export NVM_DIR="/opt/circleci/.nvm"' >> $BASH_ENV
       echo "[ -s \"$NVM_DIR/nvm.sh\" ] && . \"$NVM_DIR/nvm.sh\"" >> $BASH_ENV
+
+step_install_foundry: &step_install_foundry
+  run:
+    name: "Install Foundry"
+    working_directory: ~/
+    environment:
+      SHELL: /bin/bash
+    command: |-
+      export PATH="$PATH:$HOME/.foundry/bin"
+      echo 'export PATH=$PATH:$HOME/.foundry/bin' >> $BASH_ENV
+      curl -L https://foundry.paradigm.xyz | bash
+      foundryup
+
 jobs:
   unit-test:
     docker:
@@ -57,6 +70,7 @@ jobs:
     steps:
       - checkout
       - <<: *step_install_nvm
+      - <<: *step_install_foundry
       - run:
           name: Hardhat E2E
           command: |

--- a/plugins/resources/nomiclabs.utils.js
+++ b/plugins/resources/nomiclabs.utils.js
@@ -36,6 +36,10 @@ function normalizeConfig(config, args={}){
     ? sources = path.join(config.paths.sources, args.sources)
     : sources = config.paths.sources;
 
+  if (!path.isAbsolute(sources)) {
+    sources = path.join(config.paths.root, sources);
+  }
+
   if (config.solidity && config.solidity.compilers.length) {
     config.viaIR = isUsingViaIR(config.solidity);
   }

--- a/scripts/nomiclabs.sh
+++ b/scripts/nomiclabs.sh
@@ -50,6 +50,9 @@ npm install --silent
 npm install --save-dev --silent $PR_PATH
 cat package.json
 
+npx hardhat init-foundry
+cat foundry.toml
+
 npx hardhat coverage
 
 verifyCoverageExists


### PR DESCRIPTION
+ #853 
+ [hardhat issue 3961][1]

The @nomicfoundation/hardhat-foundry plugin makes `paths.sources` relative but it needs to be absolute when piping instrumented sources into the compilation jobs subtask here:

https://github.com/sc-forks/solidity-coverage/blob/7ad7288dca2b081c2ac0c085acbf2b5e9851b71a/plugins/hardhat.plugin.js#L27-L35

Also 
+ added hardhat-foundry to the nomiclabs project E2E 
+ added installation of foundry in CI 
+ run `npx hardhat init-foundry`

LGTM: 

![Screen Shot 2024-02-21 at 11 04 50 AM](https://github.com/sc-forks/solidity-coverage/assets/7332026/a5536151-d96c-4e32-b0d4-7ff1b97c2680)



[1]: https://github.com/NomicFoundation/hardhat/issues/3961