### PR TITLE
Check all PUSH opcodes for instr. hashes when viaIR is true

### DIFF
--- a/lib/collector.js
+++ b/lib/collector.js
@@ -6,26 +6,7 @@ class DataCollector {
   constructor(instrumentationData={}, viaIR){
     this.instrumentationData = instrumentationData;
 
-    this.validOpcodes = {
-      "PUSH1": true,
-      "DUP1": viaIR,
-      "DUP2": viaIR,
-      "DUP3": viaIR,
-      "DUP4": viaIR,
-      "DUP5": viaIR,
-      "DUP6": viaIR,
-      "DUP7": viaIR,
-      "DUP8": viaIR,
-      "DUP9": viaIR,
-      "DUP10": viaIR,
-      "DUP11": viaIR,
-      "DUP12": viaIR,
-      "DUP13": viaIR,
-      "DUP14": viaIR,
-      "DUP15": viaIR,
-      "DUP16": viaIR,
-    }
-
+    this.validOpcodes = this._getOpcodes(viaIR);
     this.lastHash = null;
     this.viaIR = viaIR;
     this.pcZeroCounter = 0;
@@ -96,6 +77,29 @@ class DataCollector {
       hash = '0x' + hash
     }
     return hash;
+  }
+
+    /**
+   * Generates a list of all the opcodes to inspect for instrumentation hashes
+   * When viaIR is true, it includes all DUPs and PUSHs, so things are a little slower.
+   * @param {boolean} viaIR
+   */
+  _getOpcodes(viaIR) {
+    let opcodes = {
+      "PUSH1": true
+    };
+
+    for (let i = 2; i <= 32; i++) {
+      const key = "PUSH" + i;
+      opcodes[key] = viaIR;
+    };
+
+    for (let i = 1; i <= 16; i++ ) {
+      const key = "DUP" + i;
+      opcodes[key] = viaIR;
+    }
+
+    return opcodes;
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test:unit": "./scripts/unit.sh",
     "test:integration": "./scripts/integration.sh",
     "test:ci": "./scripts/ci.sh",
-    "test:uint:viaIR": "VIA_IR=true ./scripts/unit.sh",
+    "test:unit:viaIR": "VIA_IR=true ./scripts/unit.sh",
     "test:integration:viaIR": "VIA_IR=true ./scripts/integration.sh",
     "test:ci:viaIR": "VIA_IR=true ./scripts/ci.sh"
   },

--- a/test/util/util.js
+++ b/test/util/util.js
@@ -92,6 +92,8 @@ function getDiffABIs(sourceName, testFile="test.sol", original="Old", current="N
 // ============================
 function instrumentAndCompile(sourceName, api={ config: {} }) {
   api.config.viaIR = process.env.VIA_IR === "true";
+  api.viaIR = process.env.VIA_IR === "true";
+
   const contract = getCode(`${sourceName}.sol`)
   const instrumenter = new Instrumenter(api.config);
   const instrumented = instrumenter.instrument(contract, filePath);


### PR DESCRIPTION
See #870 - it looked like instrumentation was getting stripped out by viaIR, but actually some hashes are being displaced onto higher PUSHn opcodes that the collector isn't tracking. 

(There's still an unhit line in #870 however ... waiting on answer to this https://github.com/sc-forks/solidity-coverage/issues/870#issuecomment-1968232584)