### PR TITLE
Check all SWAP opcodes for inst. hashes when viaIR is true

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,9 @@ jobs:
           command: |
             bash <(curl -s https://codecov.io/bash)
   e2e-zeppelin:
-    machine: true
+    machine:
+      image: ubuntu-2204:2024.01.1
+    resource_class: large
     environment:
           NODE_OPTIONS: --max_old_space_size=8192
     steps:

--- a/lib/collector.js
+++ b/lib/collector.js
@@ -99,6 +99,11 @@ class DataCollector {
       opcodes[key] = viaIR;
     }
 
+    for (let i = 1; i <= 16; i++ ) {
+      const key = "SWAP" + i;
+      opcodes[key] = viaIR;
+    }
+
     return opcodes;
   }
 

--- a/scripts/zeppelin.sh
+++ b/scripts/zeppelin.sh
@@ -8,7 +8,7 @@ set -o errexit
 # Get rid of any caches
 sudo rm -rf node_modules
 echo "NVM CURRENT >>>>>" && nvm current
-nvm use 18
+nvm use 20
 
 # Use PR env variables (for forks) or fallback on local if PR not available
 SED_REGEX="s/git@github.com:/https:\/\/github.com\//"


### PR DESCRIPTION
#870 

#871 redux, with SWAP this time. (This has to be it though - there's nowhere else they can vanish...) 

(Zeppelin sorting tests seem slow and had to up container size to churn through it)