### PR TITLE
Use fs.stat to check directory status

### DIFF
--- a/plugins/resources/plugin.utils.js
+++ b/plugins/resources/plugin.utils.js
@@ -135,9 +135,9 @@ function assembleFiles(config, skipFiles=[]){
   let targetsPath;
 
   // The targets (contractsDir) could actually be a single named file (OR a folder)
-  const extName = path.extname(config.contractsDir);
+  const isDirectory = fs.statSync(config.contractsDir).isDirectory();
 
-  if (extName.length !== 0) {
+  if (!isDirectory) {
     targets = [ path.normalize(config.contractsDir) ];
   } else {
     targetsPath = path.join(config.contractsDir, '**', '*.{sol,vy}');


### PR DESCRIPTION
#879 

Addresses EISDIR crash reported in #879 when directory names contain a period. The `path.extName` function was returning an extension in this case causing `assembleFiles` to treat the directory as a source file.  