### PR TITLE
Error if --solcoverjs passed but file is nonexistent

### DIFF
--- a/plugins/resources/plugin.utils.js
+++ b/plugins/resources/plugin.utils.js
@@ -222,7 +222,10 @@ function loadSolcoverJS(config={}){
       throw new Error(error)
     }
 
-  // Config is optional
+  // Config is optional, but if passed and not found, error
+  } else if (config.solcoverjs) {
+    const message = ui.generate('solcoverjs-fail') + " --solcoverjs flag was set but no file was found";
+    throw new Error(message);
   } else {
     coverageConfig = {};
   }

--- a/test/integration/errors.js
+++ b/test/integration/errors.js
@@ -46,6 +46,26 @@ describe('Hardhat Plugin: error cases', function() {
     verify.coverageNotGenerated(hardhatConfig);
   })
 
+  it('.solcover.js is not found', async function(){
+    const taskArgs = {
+      solcoverjs: "./file-that-does-not-exist.js"
+    }
+
+    mock.install('Simple', 'simple.js', solcoverConfig);
+    mock.hardhatSetupEnv(this);
+
+    try {
+      await this.env.run("coverage", taskArgs);
+      assert.fail()
+    } catch (err) {
+      assert(
+        err.message.includes('--solcoverjs flag was set but no file was found'),
+        `Should error if --solcoverjs passed but not found: ${err.message}`
+      );
+    }
+  })
+
+
   it('.solcover.js has incorrectly formatted option', async function(){
     solcoverConfig.port = "Antwerpen";
 


### PR DESCRIPTION
It's been a while :sweat_smile: - hope things are good on your side.

While reworking my test suite, I lost a lot of time to this peculiarity and a hard-to-spot typo on my side, so thought I'd see if there was an appetite to saving other people the bother down the line. I realise this is a breaking change though; would be happy to turn it in to a warning rather than an outright failure, if that's a concern.