### PR TITLE
Stop overwriting forking config in extendConfig

### DIFF
--- a/plugins/hardhat.plugin.js
+++ b/plugins/hardhat.plugin.js
@@ -24,16 +24,11 @@ const ui = new PluginUI();
 // Workaround for hardhat-viem-plugin and other provider redefinition conflicts
 extendConfig((config, userConfig) => {
   if (Boolean(process.env.SOLIDITY_COVERAGE)) {
-    const { cloneDeep } = require("lodash");
     const { configureHardhatEVMGas } = require('./resources/nomiclabs.utils');
     const API = require('./../lib/api');
     const api = new API({});
 
-    let hardhatNetworkForCoverage = {};
-    if (userConfig.networks && userConfig.networks.hardhat) {
-      hardhatNetworkForCoverage = cloneDeep(userConfig.networks.hardhat);
-    };
-
+    const hardhatNetworkForCoverage = {};
     configureHardhatEVMGas(hardhatNetworkForCoverage, api);
     config.networks.hardhat = Object.assign(config.networks.hardhat, hardhatNetworkForCoverage);
   }


### PR DESCRIPTION
#891 

The existing logic for `extendConfig` tries to clone the user's config and apply it to the resolved HH config after updating gas values, accidentally overwriting some necessary default fields in the forking object, which looks like this:

```ts
 forking: {
    url: 'https://opt-mainnet.g.alchemy.com/v2/....',
    enabled: true,
    httpHeaders: {},
    blockNumber: 123190000
  },
```
This isn't necessary, the `config` object is already seeded with user's values when `extendConfig` executes. 