### PR TITLE
Add irMinimum option

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ module.exports = {
 | Option <img width=200/>| Type <img width=200/> | Default <img width=1000/> | Description <img width=1000/> |
 | ------ | ---- | ------- | ----------- |
 | skipFiles | *Array* | `[]` | Array of contracts or folders (with paths expressed relative to the `contracts` directory) that should be skipped when doing instrumentation.(ex: `[ "Routers", "Networks/Polygon.sol"]`) :warning: **RUN THE HARDHAT CLEAN COMMAND AFTER UPDATING THIS**  |
-| irMinimum | *Boolean* | `[]` | Speeds up test execution times when using `viaIR` compilation setting. If your project will compile with this solc config (it may not!) this is worth a try |
+| irMinimum | *Boolean* | `[]` | Speeds up test execution times when solc is run in `viaIR` mode. If your project successfully compiles while generating coverage with this option turned on (it may not!) it's worth using |
 | modifierWhitelist | *String[]* | `[]` | List of modifier names (ex: `onlyOwner`) to exclude from branch measurement. (Useful for modifiers which prepare something instead of acting as a gate.)) |
 | mocha | *Object* | `{ }` | [Mocha options][3] to merge into existing mocha config. `grep` and `invert` are useful for skipping certain tests under coverage using tags in the test descriptions. [More...][24]|
 | measureStatementCoverage | *boolean* | `true` | Computes statement (in addition to line) coverage. [More...][34] |

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ module.exports = {
 | Option <img width=200/>| Type <img width=200/> | Default <img width=1000/> | Description <img width=1000/> |
 | ------ | ---- | ------- | ----------- |
 | skipFiles | *Array* | `[]` | Array of contracts or folders (with paths expressed relative to the `contracts` directory) that should be skipped when doing instrumentation.(ex: `[ "Routers", "Networks/Polygon.sol"]`) :warning: **RUN THE HARDHAT CLEAN COMMAND AFTER UPDATING THIS**  |
-| irMinimum | *Boolean* | `[]` | May speed up test execution times when using `viaIR` compilation setting. If your project will compile with this solc config (it may not!) it's worth a try |
+| irMinimum | *Boolean* | `[]` | Speeds up test execution times when using `viaIR` compilation setting. If your project will compile with this solc config (it may not!) it's worth a try |
 | modifierWhitelist | *String[]* | `[]` | List of modifier names (ex: `onlyOwner`) to exclude from branch measurement. (Useful for modifiers which prepare something instead of acting as a gate.)) |
 | mocha | *Object* | `{ }` | [Mocha options][3] to merge into existing mocha config. `grep` and `invert` are useful for skipping certain tests under coverage using tags in the test descriptions. [More...][24]|
 | measureStatementCoverage | *boolean* | `true` | Computes statement (in addition to line) coverage. [More...][34] |

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ module.exports = {
 | Option <img width=200/>| Type <img width=200/> | Default <img width=1000/> | Description <img width=1000/> |
 | ------ | ---- | ------- | ----------- |
 | skipFiles | *Array* | `[]` | Array of contracts or folders (with paths expressed relative to the `contracts` directory) that should be skipped when doing instrumentation.(ex: `[ "Routers", "Networks/Polygon.sol"]`) :warning: **RUN THE HARDHAT CLEAN COMMAND AFTER UPDATING THIS**  |
+| irMinimum | *Boolean* | `[]` | May speed up test execution times when using `viaIR` compilation setting. If your project will compile with this solc config (it may not!) it's worth a try |
 | modifierWhitelist | *String[]* | `[]` | List of modifier names (ex: `onlyOwner`) to exclude from branch measurement. (Useful for modifiers which prepare something instead of acting as a gate.)) |
 | mocha | *Object* | `{ }` | [Mocha options][3] to merge into existing mocha config. `grep` and `invert` are useful for skipping certain tests under coverage using tags in the test descriptions. [More...][24]|
 | measureStatementCoverage | *boolean* | `true` | Computes statement (in addition to line) coverage. [More...][34] |
@@ -113,9 +114,9 @@ module.exports = {
 | onCompileComplete[<sup>*</sup>][14] | *Function* |  | Hook run *after* compilation completes, *before* tests are run. Useful if you have secondary compilation steps or need to modify built artifacts. [More...][23]|
 | onTestsComplete[<sup>*</sup>][14] | *Function* |  | Hook run *after* the tests complete, *before* Istanbul reports are generated. [More...][23]|
 | onIstanbulComplete[<sup>*</sup>][14] | *Function* |  | Hook run *after* the Istanbul reports are generated, *before* the coverage task completes. Useful if you need to clean resources up. [More...][23]|
-| **:warning:    DEPRECATED** |  | |  |
-| configureYulOptimizer | *Boolean* | false | **(Deprecated since 0.8.7)** Setting to `true` should resolve "stack too deep" compiler errors in large projects using ABIEncoderV2 |
-| solcOptimizerDetails | *Object* | `undefined` |**(Deprecated since 0.8.7))** Must be used in combination with `configureYulOptimizer`. Allows you to configure solc's [optimizer details][1001]. Useful if the default remedy for stack-too-deep errors doesn't work in your case (See [FAQ: Running out of stack][1002] ). |
+| **:warning:    LOW LEVEL** |  | |  |
+| configureYulOptimizer | *Boolean* | false | Setting to `true` may resolve "stack too deep" compiler errors when **NOT** using `viaIR` |
+| solcOptimizerDetails | *Object* | `undefined` |Must be used in combination with `configureYulOptimizer`. Allows you to configure solc's [optimizer details][1001]. (See [FAQ: Running out of stack][1002] ). |
 
 
 [<sup>*</sup> Advanced use][14]

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ module.exports = {
 | Option <img width=200/>| Type <img width=200/> | Default <img width=1000/> | Description <img width=1000/> |
 | ------ | ---- | ------- | ----------- |
 | skipFiles | *Array* | `[]` | Array of contracts or folders (with paths expressed relative to the `contracts` directory) that should be skipped when doing instrumentation.(ex: `[ "Routers", "Networks/Polygon.sol"]`) :warning: **RUN THE HARDHAT CLEAN COMMAND AFTER UPDATING THIS**  |
-| irMinimum | *Boolean* | `[]` | Speeds up test execution times when using `viaIR` compilation setting. If your project will compile with this solc config (it may not!) it's worth a try |
+| irMinimum | *Boolean* | `[]` | Speeds up test execution times when using `viaIR` compilation setting. If your project will compile with this solc config (it may not!) this is worth a try |
 | modifierWhitelist | *String[]* | `[]` | List of modifier names (ex: `onlyOwner`) to exclude from branch measurement. (Useful for modifiers which prepare something instead of acting as a gate.)) |
 | mocha | *Object* | `{ }` | [Mocha options][3] to merge into existing mocha config. `grep` and `invert` are useful for skipping certain tests under coverage using tags in the test descriptions. [More...][24]|
 | measureStatementCoverage | *boolean* | `true` | Computes statement (in addition to line) coverage. [More...][34] |
@@ -115,7 +115,7 @@ module.exports = {
 | onTestsComplete[<sup>*</sup>][14] | *Function* |  | Hook run *after* the tests complete, *before* Istanbul reports are generated. [More...][23]|
 | onIstanbulComplete[<sup>*</sup>][14] | *Function* |  | Hook run *after* the Istanbul reports are generated, *before* the coverage task completes. Useful if you need to clean resources up. [More...][23]|
 | **:warning:    LOW LEVEL** |  | |  |
-| configureYulOptimizer | *Boolean* | false | Setting to `true` may resolve "stack too deep" compiler errors when **NOT** using `viaIR` |
+| configureYulOptimizer | *Boolean* | false | Setting to `true` lets you specify optimizer details (see next option). If no details are defined it defaults to turning on the yul optimizer and enabling stack allocation |
 | solcOptimizerDetails | *Object* | `undefined` |Must be used in combination with `configureYulOptimizer`. Allows you to configure solc's [optimizer details][1001]. (See [FAQ: Running out of stack][1002] ). |
 
 

--- a/lib/api.js
+++ b/lib/api.js
@@ -56,6 +56,7 @@ class API {
 
     this.viaIR = config.viaIR;
     this.usingSolcV4 = config.usingSolcV4;
+    this.irMinimum = config.irMinimum;
     this.solcOptimizerDetails = config.solcOptimizerDetails;
 
     this.setLoggingLevel(config.silent);

--- a/plugins/hardhat.plugin.js
+++ b/plugins/hardhat.plugin.js
@@ -73,8 +73,8 @@ subtask(TASK_COMPILE_SOLIDITY_GET_COMPILATION_JOB_FOR_FILE).setAction(async (_, 
     // instrument using `abi.encode(bytes8 covHash)`. Otherwise turn the optimizer off.
     if (!settings.viaIR) settings.optimizer.enabled = false;
 
-    //
-    // https://github.com/ethereum/solidity/issues/12533#issuecomment-1013073350
+    // Almost identical to foundry's irMinimum option - may improve performance for projects compiling with viaIR
+    // Original discussion at: https://github.com/ethereum/solidity/issues/12533#issuecomment-1013073350
     if (irMinimum) {
       settings.optimizer.details =  {
         peephole: false,
@@ -86,8 +86,8 @@ subtask(TASK_COMPILE_SOLIDITY_GET_COMPILATION_JOB_FOR_FILE).setAction(async (_, 
         constantOptimizer: false,
         yul: true,
         yulDetails: {
-          stackAllocation: false,
-          //optimizerSteps: "",
+          stackAllocation: true,
+          optimizerSteps: "",
         },
       }
     // LEGACY: This sometimes fixed a stack-too-deep bug in ABIEncoderV2 for coverage plugin versions up to 0.8.6

--- a/plugins/hardhat.plugin.js
+++ b/plugins/hardhat.plugin.js
@@ -71,19 +71,12 @@ subtask(TASK_COMPILE_SOLIDITY_GET_COMPILATION_JOB_FOR_FILE).setAction(async (_, 
 
     // Beginning with v0.8.7, we let the optimizer run if viaIR is true and
     // instrument using `abi.encode(bytes8 covHash)`. Otherwise turn the optimizer off.
-    if (!settings.viaIR) settings.optimizer.enabled = false;
+    if (!settings.viaIR || irMinimum) settings.optimizer.enabled = false;
 
     // Almost identical to foundry's irMinimum option - may improve performance for projects compiling with viaIR
     // Original discussion at: https://github.com/ethereum/solidity/issues/12533#issuecomment-1013073350
     if (irMinimum) {
       settings.optimizer.details =  {
-        peephole: false,
-        inliner: false,
-        jumpdestRemover: false,
-        orderLiterals: false,
-        deduplicate: false,
-        cse: false,
-        constantOptimizer: false,
         yul: true,
         yulDetails: {
           stackAllocation: true,

--- a/plugins/hardhat.plugin.js
+++ b/plugins/hardhat.plugin.js
@@ -79,15 +79,15 @@ subtask(TASK_COMPILE_SOLIDITY_GET_COMPILATION_JOB_FOR_FILE).setAction(async (_, 
       settings.optimizer.details =  {
         peephole: false,
         inliner: false,
-        jumpdest_remover: false,
-        order_literals: false,
+        jumpdestRemover: false,
+        orderLiterals: false,
         deduplicate: false,
         cse: false,
-        constant_optimizer: false,
+        constantOptimizer: false,
         yul: true,
-        yul_details: {
-          stack_allocation: true,
-          optimizer_steps: "",
+        yulDetails: {
+          stackAllocation: false,
+          //optimizerSteps: "",
         },
       }
     // LEGACY: This sometimes fixed a stack-too-deep bug in ABIEncoderV2 for coverage plugin versions up to 0.8.6

--- a/test/integration/standard.js
+++ b/test/integration/standard.js
@@ -380,6 +380,22 @@ describe('Hardhat Plugin: standard use cases', function() {
     verify.lineCoverage(expected);
   })
 
+  it('compiles with irMinimum setting', async function(){
+    mock.installFullProject('irMinimum');
+    mock.hardhatSetupEnv(this);
+
+    await this.env.run("coverage");
+
+    const expected = [
+      {
+        file: mock.pathToContract(hardhatConfig, 'IRMinimum.sol'),
+        pct: 100
+      }
+    ];
+
+    verify.lineCoverage(expected);
+  })
+
   it('locates .coverage_contracts correctly when dir is subfolder', async function(){
     mock.installFullProject('contract-subfolders');
     mock.hardhatSetupEnv(this);

--- a/test/sources/projects/irMinimum/.solcover.js
+++ b/test/sources/projects/irMinimum/.solcover.js
@@ -1,0 +1,5 @@
+module.exports = {
+  silent: process.env.SILENT ? true : false,
+  istanbulReporter: ['json-summary', 'text'],
+  irMinimum: true,
+}

--- a/test/sources/projects/irMinimum/contracts/IRMinimum.sol
+++ b/test/sources/projects/irMinimum/contracts/IRMinimum.sol
@@ -1,0 +1,26 @@
+pragma solidity >=0.8.0 <0.9.0;
+
+contract ContractA {
+    // 15 fn args + 1 local variable assignment
+    // will trigger stack too deep error when optimizer is off.
+    function stackTooDeep(
+      uint _a,
+      uint _b,
+      uint _c,
+      uint _d,
+      uint _e,
+      uint _f,
+      uint _g,
+      uint _h,
+      uint _i,
+      uint _j,
+      uint _k,
+      uint _l,
+      uint _m,
+      uint _n,
+      uint _o
+    ) public {
+      uint x = _a;
+    }
+}
+

--- a/test/sources/projects/irMinimum/hardhat.config.js
+++ b/test/sources/projects/irMinimum/hardhat.config.js
@@ -1,0 +1,16 @@
+require("@nomiclabs/hardhat-truffle5");
+require(__dirname + "/../plugins/nomiclabs.plugin");
+
+module.exports = {
+  solidity: {
+    version: "0.8.28",
+    settings: {
+      optimizer: {
+        enabled: true
+      },
+      evmVersion: "cancun",
+      viaIR: true
+    }
+  },
+  logger: process.env.SILENT ? { log: () => {} } : console,
+};

--- a/test/sources/projects/irMinimum/test/test_irMinimum.js
+++ b/test/sources/projects/irMinimum/test/test_irMinimum.js
@@ -1,0 +1,29 @@
+const ContractA = artifacts.require("ContractA");
+
+contract("contracta", function(accounts) {
+  let a,b;
+
+  before(async () => {
+    a = await ContractA.new();
+  })
+
+  it('a:stackTooDeep', async function(){
+    await a.stackTooDeep(
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9,
+      10,
+      11,
+      12,
+      13,
+      14,
+      15
+    );
+  })
+});


### PR DESCRIPTION
#895

Adds a convenience option `irMinimum` which configures solc to compile using the same config Zeppelin is currently using - they use viaIR normally but can get away with irMinimum.

Execution speeds locally were very similar to what they're seeing in CI (~12 min) and the job completed without problems. (Using full viaIR the machine stalls out during sorting tests which run hundreds of loop iterations).