### PR TITLE
Fix default tx gas limit after osaka

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -5,6 +5,7 @@ const path = require('path');
 const istanbul = require('sc-istanbul');
 const assert = require('assert');
 const _ = require('lodash/lang');
+const { hardforkGte, HardforkName } = require('hardhat/internal/util/hardforks');
 
 const ConfigValidator = require('./validator');
 const Instrumenter = require('./instrumenter');
@@ -17,7 +18,7 @@ const AbiUtils = require('./abi');
  * Coverage Runner
  */
 class API {
-  constructor(config={}) {
+  constructor(config={}, hardfork) {
     this.validator = new ConfigValidator();
     this.abiUtils = new AbiUtils();
     this.config = config || {};
@@ -47,8 +48,11 @@ class API {
     this.skipFiles = config.skipFiles || [];
 
     this.log = config.log || console.log;
-    this.gasLimit = 0xffffffffff                // default "gas sent" with transactions
-    this.gasLimitNumber = 0x1fffffffffffff;     // block gas limit for Hardhat
+    const isEip7825Enabled = hardfork !== undefined && HardforkName.OSAKA !== undefined
+      ? hardforkGte(hardfork, HardforkName.OSAKA)
+      : false;
+    this.gasLimit = isEip7825Enabled ? 2 ** 24 : 0xffffffffff   // default "gas sent" with transactions
+    this.gasLimitNumber = 0x1fffffffffffff;           // block gas limit for Hardhat
     this.gasPrice = 0x01;
 
     this.istanbulFolder = config.istanbulFolder || false;

--- a/plugins/hardhat.plugin.js
+++ b/plugins/hardhat.plugin.js
@@ -27,7 +27,7 @@ extendConfig((config, userConfig) => {
   if (Boolean(process.env.SOLIDITY_COVERAGE)) {
     const { configureHardhatEVMGas } = require('./resources/nomiclabs.utils');
     const API = require('./../lib/api');
-    const api = new API({});
+    const api = new API({}, config.networks.hardhat.hardfork);
 
     const hardhatNetworkForCoverage = {};
     configureHardhatEVMGas(hardhatNetworkForCoverage, api);
@@ -150,7 +150,7 @@ task("coverage", "Generates a code coverage report for tests")
   try {
     config = nomiclabsUtils.normalizeConfig(env.config, args);
     ui = new PluginUI(config.logger.log);
-    api = new API(utils.loadSolcoverJS(config));
+    api = new API(utils.loadSolcoverJS(config), config.networks.hardhat.hardfork);
 
     optimizerDetails = api.solcOptimizerDetails;
     irMinimum = api.irMinimum;


### PR DESCRIPTION
[EIP-7825](https://eips.ethereum.org/EIPS/eip-7825), included in the Osaka hardfork, sets a cap on the max gas limit that can be set for a transaction. The upcoming version of Hardhat 2 will use the Osaka hardfork by default. Since solidity-coverage sets the transaction gas limit to `0xffffffffff` by default, all transactions are rejected when running coverage.

This PR changes that default gas limit to be the EIP-7825's limit when that EIP is enabled.

This is not a permanent solution. A better solution would be to have a way to disable that EIP in Hardhat, and to do so when coverage is executed. But we want to get this working in solidity-coverage as soon as possible, so we can release this new version of Hardhat 2 without breaking the plugin.